### PR TITLE
Remove unnecessary square root calculation in ON_Line::ClosestPointTo()

### DIFF
--- a/opennurbs_line.cpp
+++ b/opennurbs_line.cpp
@@ -133,7 +133,7 @@ bool ON_Line::ClosestPointTo( const ON_3dPoint& point, double *t ) const
     const ON_3dVector D = Direction();
     const double DoD = D.LengthSquared();
     if ( DoD > 0.0 ) {
-      if ( point.DistanceTo(from) <= point.DistanceTo(to) ) {
+      if ( (point - from).LengthSquared() <= (point - to).LengthSquared() ) {
         *t = ((point - from)*D)/DoD;
       }
       else {


### PR DESCRIPTION
I believe there is no need to calculate exact distance here, squared distance should be enough and much faster