### PR TITLE
Fixed documentation typos

### DIFF
--- a/example_brep/example_brep.cpp
+++ b/example_brep/example_brep.cpp
@@ -3,7 +3,7 @@
 //
 // Copyright (c) 1993-2011 Robert McNeel & Associates. All rights reserved.
 // OpenNURBS, Rhinoceros, and Rhino3D are registered trademarks of Robert
-// McNeel & Assoicates.
+// McNeel & Associates.
 //
 // THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY.
 // ALL IMPLIED WARRANTIES OF FITNESS FOR ANY PARTICULAR PURPOSE AND OF

--- a/example_convert/example_convert.cpp
+++ b/example_convert/example_convert.cpp
@@ -57,7 +57,7 @@ int main(int argc, const char *argv[])
     return 0;
   }
 
-  // Call once in your application to initialze opennurbs library
+  // Call once in your application to initialize opennurbs library
   ON::Begin();
 
   int version = 0; // write current Rhino file
@@ -138,7 +138,7 @@ int main(int argc, const char *argv[])
 
   dump->PushIndent();
 
-  // create achive object from file pointer
+  // create archive object from file pointer
   ON_BinaryFile archive(ON::archive_mode::read3dm, archive_fp);
 
   // read the contents of the file into "model"

--- a/example_gl/example_gl.cpp
+++ b/example_gl/example_gl.cpp
@@ -3,7 +3,7 @@
 //
 // Copyright (c) 1993-2011 Robert McNeel & Associates. All rights reserved.
 // OpenNURBS, Rhinoceros, and Rhino3D are registered trademarks of Robert
-// McNeel & Assoicates.
+// McNeel & Associates.
 //
 // THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY.
 // ALL IMPLIED WARRANTIES OF FITNESS FOR ANY PARTICULAR PURPOSE AND OF
@@ -28,10 +28,10 @@
 // NOTE:
 //   Visual Studio 2005 / 8.0 was the last version of Visual
 //   studio to install the libraries and header files for
-//   Open GL auxillary functions.
+//   Open GL auxiliary functions.
 #endif
 
-#include <GL/GLaux.h>   // Open GL auxillary functions
+#include <GL/GLaux.h>   // Open GL auxiliary functions
 
 #define ON_EXAMPLE_GL_USE_GLAUX
 
@@ -40,7 +40,7 @@
 // Tested compilers:
 //   Apple Xcode 2.4.1
 //   Support for other Apple compilers is not available.
-#include <GLUT/glut.h>   // Open GL auxillary functions
+#include <GLUT/glut.h>   // Open GL auxiliary functions
 #define ON_EXAMPLE_GL_USE_GLUT
 
 #else
@@ -49,10 +49,10 @@
 //   Support for other compilers is not available
 #error Choose between OpenGL AUX or OpenGL GLUT.
 
-//#include <GLaux.h>   // Open GL auxillary functions
+//#include <GLaux.h>   // Open GL auxiliary functions
 //#define ON_EXAMPLE_GL_USE_GLAUX
 
-//#include <glut.h>   // Open GL auxillary functions
+//#include <glut.h>   // Open GL auxiliary functions
 //#define ON_EXAMPLE_GL_USE_GLUT
 
 #endif
@@ -224,10 +224,10 @@ void MY_GL_CALLBACK myGLUT_SpecialKeyEvent( int ch, int x, int y );    // for au
 // If you are using Apple's Xcode and you get a compile error
 // on the typedef below, then try using the commented out typedef.
 //
-// Apple's Xcode 2.4 likes this typedef witht the (...)
+// Apple's Xcode 2.4 likes this typedef with the (...)
 typedef void (CALLBACK* RHINO_GL_NURBS_ERROR)(...);
 //
-// Apple's Xcode 3.2 likes this typedef witht the (...)
+// Apple's Xcode 3.2 likes this typedef with the (...)
 //typedef void (CALLBACK* RHINO_GL_NURBS_ERROR)();
 #endif
 

--- a/example_read/example_read.cpp
+++ b/example_read/example_read.cpp
@@ -3,7 +3,7 @@
 //
 // Copyright (c) 1993-2011 Robert McNeel & Associates. All rights reserved.
 // OpenNURBS, Rhinoceros, and Rhino3D are registered trademarks of Robert
-// McNeel & Assoicates.
+// McNeel & Associates.
 //
 // THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY.
 // ALL IMPLIED WARRANTIES OF FITNESS FOR ANY PARTICULAR PURPOSE AND OF
@@ -99,7 +99,7 @@ static bool ReadFileHelper(
 
   dump.PushIndent();
 
-  // create achive object from file pointer
+  // create archive object from file pointer
   ON_BinaryFile archive( ON::archive_mode::read3dm, archive_fp );
 
   // read the contents of the file into "model"
@@ -234,7 +234,7 @@ static void print_help(const char* example_read_exe_name)
   printf("    -chunkdump\n");
   printf("      Does a chunk dump instead of reading the file's contents.\n");
   printf("    -recursive\n");
-  printf("      Recursivly reads files in subdirectories.\n");
+  printf("      Recursively reads files in subdirectories.\n");
   printf("\n");
   printf("EXAMPLE:\n");
   printf("  %s -out:list.txt -resursive .../example_files\n",example_read_exe_name);
@@ -300,7 +300,7 @@ int main( int argc, const char *argv[] )
     return 0;
   }
 
-  // Call once in your application to initialze opennurbs library
+  // Call once in your application to initialize opennurbs library
   ON::Begin();
 
   // default dump is to stdout

--- a/example_roundtrip/example_roundtrip.cpp
+++ b/example_roundtrip/example_roundtrip.cpp
@@ -14,7 +14,7 @@ int main( int argc, const char *argv[] )
     return 0;
   }
 
-  // Call once in your application to initialze opennurbs library
+  // Call once in your application to initialize opennurbs library
   ON::Begin();
 
   // default dump is to stdout
@@ -60,7 +60,7 @@ int main( int argc, const char *argv[] )
 
     dump->PushIndent();
 
-    // create achive object from file pointer
+    // create archive object from file pointer
     ON_BinaryFile archive( ON::archive_mode::read3dm, archive_fp );
 
     // read the contents of the file into "model"

--- a/example_test/example_test.cpp
+++ b/example_test/example_test.cpp
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 1993-2018 Robert McNeel & Associates. All rights reserved.
 // OpenNURBS, Rhinoceros, and Rhino3D are registered trademarks of Robert
-// McNeel & Assoicates.
+// McNeel & Associates.
 //
 // THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY.
 // ALL IMPLIED WARRANTIES OF FITNESS FOR ANY PARTICULAR PURPOSE AND OF
@@ -133,7 +133,7 @@ static const ONX_ErrorCounter Internal_TestModelRead(
   
   /////
   //
-  // Read the orginal file
+  // Read the original file
   //
   text_log.PushIndent();
   ONX_ModelTest test;
@@ -293,7 +293,7 @@ static const ONX_ErrorCounter Internal_TestModelRead(
           : model_component->NameHash();
         if (false == name_hash.IsValidAndNotEmpty())
         {
-          ON_ERROR("model compoent name is not valid.");
+          ON_ERROR("model component name is not valid.");
           continue; 
         }
         if (name_hash != item.NameHash())
@@ -634,13 +634,13 @@ static void Internal_PrintHelp(
   text_log.Print("      Displays this message.\n");
   text_log.Print("    -out\n");
   text_log.Print("      If -out is not present, output is written to stdout.\n");
-  text_log.Print("      If :outfilename.txt is appended to -out, output is written to the specifed file.\n");
+  text_log.Print("      If :outfilename.txt is appended to -out, output is written to the specified file.\n");
   text_log.Print("      If :stdout is appended to -out, output is sent to stdout.\n");
   text_log.Print("      If :null is appended to -out, no output is written.\n");
-  text_log.Print("      Otherise output is written to %s.\n",static_cast<const char*>(default_out_filename));
+  text_log.Print("      Otherwise output is written to %s.\n",static_cast<const char*>(default_out_filename));
   text_log.Print("    -recursive\n");
   text_log.Print("    -r\n");
-  text_log.Print("      Recursivly reads files in subfolders.\n");
+  text_log.Print("      Recursively reads files in subfolders.\n");
   text_log.Print("      If a :N is appended to the option, N limits the recursion depth.\n");
   text_log.Print("      -recursive:1 reads all 3dm files in the folder and does not recurse.\n");
   text_log.Print("    -verbose\n");
@@ -902,7 +902,7 @@ int main( int argc, const char *argv[] )
     return 0;
   }
 
-  // Call once in your application to initialze opennurbs library
+  // Call once in your application to initialize opennurbs library
   ON::Begin();
 
   // default text_log is to stdout

--- a/example_userdata/example_userdata.cpp
+++ b/example_userdata/example_userdata.cpp
@@ -213,7 +213,7 @@ int main()
   ud->m_my_line.to.Set(1.0,1.0,1.0);
   ud->m_my_string = "my user data";
 
-  // This attaches the user data to point.  When the point is destroied,
+  // This attaches the user data to point.  When the point is destroyed,
   // the user data will be destroyed.  
   //
   point.AttachUserData(ud);

--- a/example_write/example_write.cpp
+++ b/example_write/example_write.cpp
@@ -3,7 +3,7 @@
 //
 // Copyright (c) 1993-2011 Robert McNeel & Associates. All rights reserved.
 // OpenNURBS, Rhinoceros, and Rhino3D are registered trademarks of Robert
-// McNeel & Assoicates.
+// McNeel & Associates.
 //
 // THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY.
 // ALL IMPLIED WARRANTIES OF FITNESS FOR ANY PARTICULAR PURPOSE AND OF
@@ -90,7 +90,7 @@ ON_3dmObjectAttributes* Internal_CreateManagedAttributes(
 
 static bool write_points_example( const wchar_t* filename, ON_TextLog& error_log  )
 {
-  // example demonstrates how to write a singe points and point clouds
+  // example demonstrates how to write a single points and point clouds
   ONX_Model model;
   INTERNAL_INITIALIZE_MODEL(model);
 

--- a/opennurbs.h
+++ b/opennurbs.h
@@ -34,7 +34,7 @@
 
 #include "opennurbs_defines.h"      /* openNURBS defines and enums */
 #include "opennurbs_error.h"        /* error handling */
-#include "opennurbs_memory.h"       /* memory managment (onmalloc(), onrealloc(), onfree(), ...) */
+#include "opennurbs_memory.h"       /* memory management (onmalloc(), onrealloc(), onfree(), ...) */
 #include "opennurbs_rand.h"         /* random number generator */
 #include "opennurbs_crc.h"          /* cyclic redundancy check tool */
 #include "opennurbs_uuid.h"         /* universally unique identifiers (UUID, a.k.a, GUID) */

--- a/opennurbs_3dm.h
+++ b/opennurbs_3dm.h
@@ -219,7 +219,7 @@
 #define TCODE_LIGHT_RECORD_END        (TCODE_INTERFACE | TCODE_SHORT | 0x006F)
 
 /* records in user table 
-     Each user table entery has two top level chunks, a TCODE_USER_TABLE_UUID chunk
+     Each user table entry has two top level chunks, a TCODE_USER_TABLE_UUID chunk
      and a TCODE_USER_RECORD chunk.
 */
 

--- a/opennurbs_3dm_attributes.cpp
+++ b/opennurbs_3dm_attributes.cpp
@@ -1037,7 +1037,7 @@ void ON_3dmObjectAttributes::Dump( ON_TextLog& dump ) const
     // When mat_source is not (ON::object_material_source::material_from_object. This causes the
     // 3dm content to vary in a way that content hashing must ignore. The sample file
     // C:\dev\github\mcneel\rhino\src4\opennurbs\example_files\V5\v5_teacup.3dm is an example.
-    // It's old enough that it contians material index values >= 0 that are not saved
+    // It's old enough that it contains material index values >= 0 that are not saved
     // by SaveAs V5 writing code since circa 2010 or earlier.
     dump.Print("object material index = %d\n", m_material_index);
   }

--- a/opennurbs_3dm_attributes.h
+++ b/opennurbs_3dm_attributes.h
@@ -230,13 +230,13 @@ public:
   // Layer definitions in an OpenNURBS model are stored in a layer table.
   // The layer table is conceptually an array of ON_Layer classes.  Every
   // OpenNURBS object in a model is on some layer.  The object's layer
-  // is specified by zero based indicies into the ON_Layer array.
+  // is specified by zero based indices into the ON_Layer array.
   int m_layer_index;
 
   // Linetype definitions in an OpenNURBS model are stored in a linetype table.
   // The linetype table is conceptually an array of ON_Linetype classes.  Every
   // OpenNURBS object in a model references some linetype.  The object's linetype
-  // is specified by zero based indicies into the ON_Linetype array.
+  // is specified by zero based indices into the ON_Linetype array.
   // index 0 is reserved for continuous linetype (no pattern)
   int m_linetype_index;
 
@@ -346,7 +346,7 @@ public:
   // Display order used to force objects to be drawn on top or behind each other
   // 0  = draw object in standard depth buffered order
   // <0 = draw object behind "normal" draw order objects
-  // >0 = draw object on top of "noraml" draw order objects
+  // >0 = draw object on top of "normal" draw order objects
   // Larger number draws on top of smaller number.
   int m_display_order;
 
@@ -467,7 +467,7 @@ public:
     For a given display material id, there can be multiple
     viewports.  If there is a display reference in the
     list with a nil viewport id, then the display material
-    will be used in all viewports that are not explictly
+    will be used in all viewports that are not explicitly
     referenced in other ON_DisplayMaterialRefs.
 
   Parameters:
@@ -574,7 +574,7 @@ public:
 
   /*
   Returns:
-    Number of diplay material refences.
+    Number of display material references.
   */
   int DisplayMaterialRefCount() const;
 

--- a/opennurbs_3dm_settings.cpp
+++ b/opennurbs_3dm_settings.cpp
@@ -276,12 +276,12 @@ double ON_UnitSystem::MetersPerUnit() const
   //   For standard units, this function returns the WRONG value (inverse of the correct value).
   //   The reason is the Rhino 6 VRay plug-in assumes the incorrect value is returned
   //   and V6 VRay does not work correctly in Rhino 7 if the correct value is returned.
-  //   After some discussion (see the bug above), we will leave the invers bug in
+  //   After some discussion (see the bug above), we will leave the inverse bug in
   //   ON_UnitSystem::MetersPerUnit(), deprecate ON_UnitSystem::MetersPerUnit(),
   //   and add a new function that returns the correct answer.
   if (ON::LengthUnitSystem::CustomUnits == m_unit_system)
   {
-    // correct answer for custome units - V6 behavior.
+    // correct answer for custom units - V6 behavior.
     return m_meters_per_custom_unit; //
   }
 
@@ -2690,7 +2690,7 @@ bool ON_3dmView::Write( ON_BinaryArchive& file ) const
         rc = file.WriteInt( m_view_type );
         if (!rc) break;
         
-        // obsolete values - superceded by m_page_settings
+        // obsolete values - superseded by m_page_settings
         rc = file.WriteDouble( m_page_settings.m_width_mm );
         if (!rc) break;
 
@@ -5410,7 +5410,7 @@ void ON_3dmSettings::Dump( ON_TextLog& dump ) const
     if ( ON_UNSET_INT_INDEX != m_V5_current_dimension_style_index)
       dump.Print("Current V5 dimstyle index = %d\n",m_V5_current_dimension_style_index);
     dump.Print("Current wire density = %d\n",m_current_wire_density);
-    dump.Print("Linetype diaplay scale = %g\n",m_linetype_display_scale);
+    dump.Print("Linetype display scale = %g\n",m_linetype_display_scale);
   }
   dump.PopIndent();
 

--- a/opennurbs_3dm_settings.h
+++ b/opennurbs_3dm_settings.h
@@ -243,7 +243,7 @@ private:
   //     world views. 
   //   * ON_DimStyle::DimScale() is ignored in page and 
   //     detail views. 
-  //   * ON_DetailView::m_page_per_model_ratio is ingored
+  //   * ON_DetailView::m_page_per_model_ratio is ignored
   //     for annotation objects in detail views, other
   //     geometry is scaled.
   //
@@ -1225,7 +1225,7 @@ public:
 
   // As of 7 February 2012, the m_idef_link_update setting
   // controls if, when and how linked and linked_and_embedded
-  // instance defintions are updated when the source archive
+  // instance definitions are updated when the source archive
   // that was used to create the idef has changed.
   int m_idef_link_update = 1;  
       // 1 = prompt - ask the user if the idef should be updated.
@@ -1396,7 +1396,7 @@ public:
   //   @untitled table
   //   0       boundary + "knot" wires 
   //   1       boundary + "knot" wires + 1 interior wire if no interior "knots"
-  //   N>=2    boundry + "knot" wires + (N-1) interior wires
+  //   N>=2    boundary + "knot" wires + (N-1) interior wires
   int m_current_wire_density = 1;
 
   ON_3dmRenderSettings m_RenderSettings = ON_3dmRenderSettings::Default;

--- a/opennurbs_annotationbase.cpp
+++ b/opennurbs_annotationbase.cpp
@@ -174,7 +174,7 @@ static bool Internal_UpdateOverrideCandidateParentId(
     if (ON_nil_uuid == archive_parent_id)
       break;
 
-    // We are reading a worksession reference model or reference style linked instance defintion.
+    // We are reading a worksession reference model or reference style linked instance definition.
     // The ids in the reference file may have had a collision with ids in the active model
     // and been changed.
     const ON_ManifestMapItem parent_id_map_item = archive.ManifestMap().MapItemFromSourceId(archive_parent_id);
@@ -194,7 +194,7 @@ static bool Internal_UpdateOverrideCandidateParentId(
     if (model_parent_id == archive_parent_id)
       return false; // common situation - no change reqired
 
-    // We are reading a worksession reference model or reference style linked instance defintion.
+    // We are reading a worksession reference model or reference style linked instance definition.
     // The ids in the reference file may have had a collision with ids in the active model
     // and been changed.
     override_candidate->SetParentId(model_parent_id);
@@ -3028,13 +3028,13 @@ const class ON_Font& ON_Annotation::Font(const ON_DimStyle* parent_style) const
 
 const class ON_Font& ON_Annotation::FontCharacteristics(const ON_DimStyle* parent_style) const
 {
-  // FontCharacteristics() queries inforation that is set by calling ON_DimStyle.SetFont()
+  // FontCharacteristics() queries information that is set by calling ON_DimStyle.SetFont()
   return Internal_StyleForFieldQuery(parent_style,ON_DimStyle::field::Font).FontCharacteristics();
 }
 
 const bool ON_Annotation::FontSubstituted(const ON_DimStyle* parent_style) const
 {
-  // FontSubstituted() queries inforation that is set by calling ON_DimStyle.SetFont()
+  // FontSubstituted() queries information that is set by calling ON_DimStyle.SetFont()
   return Internal_StyleForFieldQuery(parent_style,ON_DimStyle::field::Font).FontSubstituted();
 }
 

--- a/opennurbs_annotationbase.h
+++ b/opennurbs_annotationbase.h
@@ -408,7 +408,7 @@ public:
   /*
   Returns:
     True if this text position information used to create this text
-    is identical to the text position paramters on dimstyle.
+    is identical to the text position parameters on dimstyle.
   */
   bool EqualTextPositionProperties(
     const class ON_DimStyle* dimstyle
@@ -505,7 +505,7 @@ private:
     Gets the appropriate ON_DimStyle to query for a property value.
   Parameters:
     parent_style - [in]
-      parent style pased to the ON_Annotation query function
+      parent style passed to the ON_Annotation query function
     field_id - [in]
       field being queried - this is used to select between using the override style or the parent style.
   */
@@ -930,7 +930,7 @@ public:
 
 
 /*
-  A simple dot with text that doesn't rotate witn the world axes
+  A simple dot with text that doesn't rotate with the world axes
 */
 class ON_CLASS ON_TextDot : public ON_Geometry
 {

--- a/opennurbs_apple_nsfont.cpp
+++ b/opennurbs_apple_nsfont.cpp
@@ -476,7 +476,7 @@ const ON_wString ON_Font::AppleCTFontFaceName(
       return style_name;
     }
     
-    // Fallback - In Sep 12, 2018 tests of 603 faces, the no longer needed with the swtich to CTFont
+    // Fallback - In Sep 12, 2018 tests of 603 faces, the no longer needed with the switch to CTFont
     // Leaving this here to handle unknown buggy fonts.
     const ON_wString family_and_face_name = ON_Font::AppleCTFontDisplayName(apple_font);
     const ON_wString family_name = ON_Font::AppleCTFontFamilyName(apple_font);
@@ -983,7 +983,7 @@ unsigned int ON_AppleFontGlyphIndex(
     if (utf16_count < 1 || utf16_count > 2)
       break;
 
-    // UniChar is used for Apple UTF-16 endcodings
+    // UniChar is used for Apple UTF-16 encodings
     const UniChar apple_utf16[3] = { (UniChar)utf16[0], (UniChar)utf16[1], (UniChar)0 };
 
     // glyphs[] includes an element for the NULL terminator and an extra element
@@ -1075,7 +1075,7 @@ bool ON_AppleFontGetGlyphOutline(
   {
     // Apple's Mac OS CTFontCreatePathForGlyph() ignores subfigures that
     // are lines. These are common in single stroke fonts. Typical results
-    // with singel stroke files are things like the R is missing it's right leg, 
+    // with single stroke files are things like the R is missing it's right leg, 
     // h is missing is left side line, and so on. 
     // Freetype has many bugs, but it can parse some common single stroke files. 
     // Freetype is basically a file reading utility that can parse outline 

--- a/opennurbs_arc.h
+++ b/opennurbs_arc.h
@@ -109,7 +109,7 @@ public:
   Parameters:
     plane - [in]
       The plane x, y and z axis are used to defines the circle
-      plane's x, y and z axis.  The plane origin is ignorned.
+      plane's x, y and z axis.  The plane origin is ignored.
     center - [in]
       circle's center point
     radius - [in]
@@ -221,7 +221,7 @@ public:
   Parameters:
     plane - [in]
       The plane x, y and z axis are used to defines the circle
-      plane's x, y and z axis.  The plane origin is ignorned.
+      plane's x, y and z axis.  The plane origin is ignored.
     center - [in]
       circle's center point
     radius - [in]

--- a/opennurbs_arccurve.cpp
+++ b/opennurbs_arccurve.cpp
@@ -533,7 +533,7 @@ bool ON_ArcCurve::Evaluate( // returns false if unable to evaluate
     // is one example.  The issue is that the trig function with the
     // largest derivative has more pecise sensitivity to changes in
     // angle and in orger to get as precise an evaluation as possible,
-    // it is inportant to allow non-zero values of one trig function
+    // it is important to allow non-zero values of one trig function
     // even when the other is being rounded to +1 or -1.
     //
     ////if ( fabs(c) < ON_EPSILON || fabs(s) > 1.0-ON_EPSILON )
@@ -887,7 +887,7 @@ bool ON_Arc::GetRadianFromNurbFormParameter(double NurbParameter, double* Radian
 {
 	//  TRR#53994.
 	// 16-Sept-09  Replaced this code so we dont use LocalClosestPoint.
-	// In addition to being slower than neccessary the old method suffered from getting the
+	// In addition to being slower than necessary the old method suffered from getting the
 	// wrong answer at the seam of a full circle,  This probably only happened with large 
 	// coordinates where many digits of precision get lost.
 

--- a/opennurbs_arccurve.h
+++ b/opennurbs_arccurve.h
@@ -374,7 +374,7 @@ public:
 
   /////////////////////////////////////////////////////////////////
 
-  ON_Arc m_arc = ON_Arc::UnitCircle; // defualt = radius 1 circle in x-y plane
+  ON_Arc m_arc = ON_Arc::UnitCircle; // default = radius 1 circle in x-y plane
   
   ON_Interval m_t = ON_Interval::ZeroToTwoPi;
 

--- a/opennurbs_archive.cpp
+++ b/opennurbs_archive.cpp
@@ -556,7 +556,7 @@ ON_BinaryArchive::eStorageDeviceError ON_BinaryArchive::StorageDeviceErrorFromUn
   ON_ENUM_FROM_UNSIGNED_CASE(ON_BinaryArchive::eStorageDeviceError::UnknownDeviceError);
   }
 
-  ON_ERROR("Invalid storage_device_error_as_unsigned parmeter.");
+  ON_ERROR("Invalid storage_device_error_as_unsigned parameter.");
   return ON_BinaryArchive::eStorageDeviceError::UnknownDeviceError;
 }
 
@@ -741,7 +741,7 @@ bool ON_BinaryArchive::SeekFromStart( ON__UINT64 bytes_from_start )
 
   if (0 != CurrentPosition() )
   {
-    // Internal_SeekToStart() is a pure virutal function that must overridden.
+    // Internal_SeekToStart() is a pure virtual function that must overridden.
     if (!Internal_SeekToStartOverride())
     {
       ON_ERROR("Internal_SeekToStartOverride() failed.");
@@ -769,7 +769,7 @@ bool ON_BinaryArchive::SeekBackward( ON__UINT64 bytes_backward )
 
 bool ON_BinaryArchive::Internal_SeekCur( bool bForward, ON__UINT64 offset )
 {
-  // Internal_SeekFromCurrentPosition() is a pure virutal function that must overridden. 
+  // Internal_SeekFromCurrentPosition() is a pure virtual function that must overridden. 
   // Some implementations may use signed 4 byte int in critical places.
   // SeekForward() will work correctly in this worst case situation.
   if (UnsetMode())
@@ -2616,7 +2616,7 @@ bool ON_BinaryArchive::ReadLinetypeSegment(ON_LinetypeSegment& seg)
   bool rc = ReadDouble(&seg.m_length);
   if (rc)
   {
-    // ON_LinetypeSegment::eSegType::Unset was not added initialy, so juggling values is required for
+    // ON_LinetypeSegment::eSegType::Unset was not added initially, so juggling values is required for
     // Unset, stLine and stSpace.  Any future values with work without
     // juggling.
     unsigned int i = 0;
@@ -2645,7 +2645,7 @@ bool ON_BinaryArchive::WriteLinetypeSegment( const ON_LinetypeSegment& seg)
   bool rc = WriteDouble(seg.m_length);
   if (rc)
   {
-    // ON_LinetypeSegment::eSegType::Unset was not added initialy, so juggling values is required for
+    // ON_LinetypeSegment::eSegType::Unset was not added initially, so juggling values is required for
     // Unset, stLine and stSpace.  Any future values with work without
     // juggling.
     unsigned int i;
@@ -2724,7 +2724,7 @@ bool ON_BinaryArchive::WriteBool( bool b )
 
 bool ON_BinaryArchive::WriteBoolTrue()
 {
-  // true is saved a a singel byte with value = 1.
+  // true is saved a a single byte with value = 1.
   const unsigned char c = 1;
   return WriteChar(c);
 }
@@ -3631,7 +3631,7 @@ bool ON_BinaryArchive::ReadWideString(
       }
       else if (chunk_byte_count > 0)
       {
-        // This should never happend and is probably a bug.
+        // This should never happened and is probably a bug.
         // If it occurs due to invalid input, describe the situation
         // in this comment.
         ON_ERROR("char buffer reading stalled.");
@@ -3665,7 +3665,7 @@ bool ON_BinaryArchive::ReadWideString(
           }
           if (c < 0 || c > 127)
           {
-            // 512 bytes of with the hight bit set is not what was written and it cannot be an "overly long" UTF-8 encoding.
+            // 512 bytes of with the height bit set is not what was written and it cannot be an "overly long" UTF-8 encoding.
             // The arcive contents have been damaged.
             ON_ERROR("archive contents damaged.");
             break;
@@ -4889,7 +4889,7 @@ bool ON_BinaryArchive::WriteObjectUserData( const ON_Object& object )
           {
             // 22 January 2004 Dale Lear
             //   Disable crc checking when writing the
-            //   unknow user data block.
+            //   unknown user data block.
             //   This has to be done so we don't get an extra
             //   32 bit CRC calculated on the block that
             //   ON_UnknownUserData::Write() writes.  The
@@ -5076,7 +5076,7 @@ int ON_BinaryArchive::ReadObjectHelper( ON_Object** ppObject )
         }
         if ( nullptr != pID && uuid != pID->Uuid() )
         {
-          ON_ERROR("ON_BinaryArchive::ReadObject() - uuid does not match intput pObject's class id.");
+          ON_ERROR("ON_BinaryArchive::ReadObject() - uuid does not match input pObject's class id.");
           pID = 0;
           rc = 2;
           break;
@@ -5091,7 +5091,7 @@ int ON_BinaryArchive::ReadObjectHelper( ON_Object** ppObject )
       {
         // If you get here and you are not calling ON::Begin() at some point in your
         // executable, then call ON::Begin() to force all class definition to be linked.
-        // If you are callig ON::Begin(), then either the uuid is garbage or you are 
+        // If you are calling ON::Begin(), then either the uuid is garbage or you are 
         // attempting to read an object with old code.
         // Visit http://www.opennurbs.org to get the latest OpenNURBS code.
         ON_WARNING("ON_BinaryArchive::ReadObject() ON_ClassId::ClassId(uuid) returned nullptr.");
@@ -5439,7 +5439,7 @@ bool ON_BinaryArchive::ReadObjectUserData( ON_Object& object )
   {
     // Note:
     //  The destructor ~ON_ReadChunkHelper() may set bChunkReadSuccess
-    //  An example of this case occures when reading the corrupt file
+    //  An example of this case occurs when reading the corrupt file
     //  attached to bug report RH-22547.
     ON_ReadChunkHelper ch(*this,bChunkReadSuccess);
     if ( !bChunkReadSuccess )
@@ -5461,7 +5461,7 @@ bool ON_BinaryArchive::ReadObjectUserData( ON_Object& object )
         // A short TCODE_OPENNURBS_CLASS_END chunk marks the end of the opennurbs class
         // Checking for zero here fixes RH-22547 which was a report of Rescue3dm taking
         // hours to read a damaged file that was filled with large blocks of zeros 
-        // caused by some form of storage media or tranmission corruption.
+        // caused by some form of storage media or transmission corruption.
         rc = false; // there should never be a typecode of zero.
         break;
       }
@@ -5725,7 +5725,7 @@ bool ON_BinaryArchive::BeginWrite3dmChunk( unsigned int typecode, int value )
     }
     else
     {
-      // treat value paramter is a signed int
+      // treat value parameter is a signed int
       value64 = value;
     }
   }
@@ -9526,7 +9526,7 @@ bool ON_BinaryArchive::FindMisplacedTable(
         continue;
 
       length_of_user_uuid_and_header = buffer - buffer0;
-      // At this point we should be postioned at the table_record_tcode = TCODE_USER_RECORD chunk
+      // At this point we should be positioned at the table_record_tcode = TCODE_USER_RECORD chunk
     }
 
     // see if the start of the buffer contains the 4 byte typecode value = table_record_tcode.
@@ -12122,7 +12122,7 @@ bool ON_BinaryArchive::Read3dmV1AttributesOrMaterial(
                          ON__3dmV1_XDATA* xdata
                          )
 {
-  // Check ReadV1Material() if you fix any bugs in the mateial related items
+  // Check ReadV1Material() if you fix any bugs in the material related items
 
   if ( 0 != xdata )
   {
@@ -12528,7 +12528,7 @@ int ON_BinaryArchive::Read3dmV1Material( ON_Material** ppMaterial )
           break;
         if ( !EndRead3dmChunk() )
           break;
-        // attributes and material informtion follow the TCODE_COMPRESSED_MESH_GEOMETRY chunk
+        // attributes and material information follow the TCODE_COMPRESSED_MESH_GEOMETRY chunk
         if ( !Read3dmV1AttributesOrMaterial( nullptr, &material, bHaveMat, TCODE_ENDOFTABLE ) )
           rc = -1;
         // if appropriate, rc will get set to +1 below
@@ -16449,7 +16449,7 @@ bool ON_BinaryArchive::MaskReadError( ON__UINT64 sizeof_request, ON__UINT64 size
     return true;
   }
 
-  return false; // parial read not permitted at this time.
+  return false; // partial read not permitted at this time.
 }
 
 ON__UINT64 ON_BinaryArchive::ReadBuffer( ON__UINT64 sizeof_buffer, void* buffer )
@@ -16605,7 +16605,7 @@ size_t ON_BinaryArchive::Read( size_t count, void* p )
         }
         else if ( false == MaskReadError(count,readcount) )
         {
-          // error occured
+          // error occurred
           SetStorageDeviceError(ON_BinaryArchive::eStorageDeviceError::ReadFailed);
           ON_ERROR("Internal_ReadOverride(count, p) failed.");
         }
@@ -16918,7 +16918,7 @@ bool ON_BinaryFile::Internal_SeekFromCurrentPositionOverride( int offset )
   // I could not reproduce these 100x slow saves in testing on McNeel's
   // network but we have a good quality network and a server that's
   // properly tuned.  My guess is that the slow saves are happening
-  // on servers that do a poor job of cacheing because they are starved
+  // on servers that do a poor job of caching because they are starved
   // for memory and/or heavily used at the time of the save.
   //
   // To speed up network saves, ON_BinaryFile can optionally use

--- a/opennurbs_archive.h
+++ b/opennurbs_archive.h
@@ -36,7 +36,7 @@ public:
   /*
   Description:
     Compare contents of buffers.
-  Paramters:
+  Parameters:
     a - [in]
     b - [in]
   Returns:
@@ -185,7 +185,7 @@ public:
   /*
   Parameters:
     offset - [in]
-      number of bytes to seek from the end fo the buffer.
+      number of bytes to seek from the end of the buffer.
   Returns:
     True if successful.
     False if the seek would result in a file position
@@ -216,7 +216,7 @@ public:
   Remarks:
     Call this function after creating an ON_Buffer that will persist for
     and extended amount of time. There are never more than 16 pages of
-    unsued memory (16*4096 bytes on most computers) in an ON_Buffer.
+    unused memory (16*4096 bytes on most computers) in an ON_Buffer.
     Compact() can be called at any time, but calling Compact() the then
     writing at the end of the buffer is not an efficient use of time
     or memory.
@@ -366,7 +366,7 @@ public:
 public:
   ON__UINT64 m_start_offset=0; // When reading or writing 3dm archives, this is the
                              // archive offset (file position) of first byte of 
-                             // chunk information conent.
+                             // chunk information content.
   
   ON__UINT64 m_end_offset=0; // When writing 3dm archives, this is the archive 
                            // offset (file position) of the byte immediately after
@@ -521,7 +521,7 @@ public:
   Parameters:
     component_type - [in]
       If component_type is ON_ModelComponent::Type::Unset or ON_ModelComponent::Type::Mixed,
-      then the every explict component type is counted.
+      then the every explicit component type is counted.
   Returns:
     Total number of model components of the specified type in this manifest. 
   Remarks:
@@ -535,7 +535,7 @@ public:
   Parameters:
     component_type - [in]
       If component_type is ON_ModelComponent::Type::Unset or ON_ModelComponent::Type::Mixed,
-      then the every explict component type is counted.
+      then the every explicit component type is counted.
   Returns:
     Number of model components of the specified type in this manifest. 
   Remarks:
@@ -550,7 +550,7 @@ public:
   Parameters:
     component_type - [in]
       If component_type is ON_ModelComponent::Type::Unset or ON_ModelComponent::Type::Mixed,
-      then the every explict component type is counted.
+      then the every explicit component type is counted.
   Returns:
     Number of active model components of the specified type in this manifest. 
   Remarks:
@@ -565,7 +565,7 @@ public:
   Parameters:
     component_type - [in]
       If component_type is ON_ModelComponent::Type::Unset or ON_ModelComponent::Type::Mixed,
-      then the every explict component type is counted.
+      then the every explicit component type is counted.
   Returns:
     Number of model components of the specified type in this manifest that have IsDeleted() = true.
   Remarks:
@@ -797,7 +797,7 @@ public:
     Often when an object is modified, the original and new
     object have the same id but different serial numbers. The original is
     deleted. When the item is undeleted for the object, the runtime
-    serial number needs to be udated.
+    serial number needs to be updated.
   */
   const class ON_ComponentManifestItem& UndeleteComponentAndChangeRuntimeSerialNumber(
     ON_UUID item_id,
@@ -852,7 +852,7 @@ public:
       then ON_ModelComponent::ComponentTypeToString(component_type) is used as base_name
     suffix_separator - [in]
       empty or the string to place between base_name and the suffix when searching for an
-      unsued name.
+      unused name.
     suffix0 - [in]
       If a suffix needs to be appended, the search for a 
       unused name begins with the suffix values suffix0+1.
@@ -1557,7 +1557,7 @@ public:
   /*
   Parameters:
     map_item - [in]
-      The source settings must exacty match source settings of an existing map.
+      The source settings must exactly match source settings of an existing map.
       The destination settings are the new values to assign.
   Return:
     True if a mapping was successfully updated (even when the destation settings did not change).
@@ -1569,7 +1569,7 @@ public:
   /*
   Parameters:
     map_item - [in]
-      The source settings must exacty match source settings of an existing map.
+      The source settings must exactly match source settings of an existing map.
       The destination settings are the new values to assign.
     bIgnoreSourceIndex - [in]
       If true, the value of map_item.SourceIndex() is ignored.
@@ -1867,18 +1867,18 @@ public:
   // Number of crc errors found during archive reading.
   // If > 0, then the archive is corrupt. See the table 
   // status information below to determine where the 
-  // errors occured.
+  // errors occurred.
   unsigned int m_crc_error_count = 0;
 
   // Number of other types of serious errors found during archive reading
   // or writing.
   // If > 0, then the archive is corrupt. See the table status information
-  // below to determine where the errors occured.
+  // below to determine where the errors occurred.
   unsigned int m_critical_error_count = 0;
 
   // Number of other types of serious errors found during archive reading.
   // If > 0, then the archive is corrupt. See the table status information
-  // below to determine where the errors occured.
+  // below to determine where the errors occurred.
   unsigned int m_recoverable_error_count = 0;
   
   enum class TableState : unsigned int 
@@ -2004,7 +2004,7 @@ public:
   Returns:
      Endian-ness of the cpu reading this file.
   Remarks:
-    3dm files are alwasy saved with little endian byte order.
+    3dm files are always saved with little endian byte order.
   */
   ON::endian Endian() const; // endian-ness of cpu
 
@@ -2015,7 +2015,7 @@ public:
   /*
   Description:
     Expert user function that uses Read() to load a buffer.
-  Paramters:
+  Parameters:
     sizeof_buffer - [in] number of bytes to attempt to read.
     buffer - [out] read bytes are stored in this buffer
   Returns:
@@ -2985,7 +2985,7 @@ public:
   /*
   Description:
     Specify the serialization option for object user data and user tables 
-    that are not explicity set by SetShouldSerializeUserDataItem().
+    that are not explicitly set by SetShouldSerializeUserDataItem().
   Parameters:
     bSerialize - [in]
   Remarks:
@@ -3094,9 +3094,9 @@ public:
     In rare cases, experts testing handling of corrupt 3dm files need to
     write a 3dm archive that is corrupt. In this rare testing situation,
     those experts should call IntentionallyWriteCorrupt3dmStartSectionForExpertTesting()
-    exactly one time before they begin writing the file. The 32 byte idendifier will
+    exactly one time before they begin writing the file. The 32 byte identifier will
     replace the 1st 3 spaces with a capital X to mimic a file that became corrupt
-    whle residing on storage media.
+    while residing on storage media.
   */
   void IntentionallyWriteCorrupt3dmStartSectionForExpertTesting();
 
@@ -3557,20 +3557,20 @@ public:
 
   /*
    Description:
-     Reads instance definitions from instance defintion table.
+     Reads instance definitions from instance definition table.
   
    Parameters:
-     ppInstanceDefinition - If an instance defintion is
-     read, an instance defintion is created by calling new 
+     ppInstanceDefinition - If an instance definition is
+     read, an instance definition is created by calling new 
      ON_InstanceDefinition(), initialized with values stored
-     in the archive, and a pointer to the new instance defintion
+     in the archive, and a pointer to the new instance definition
      is returned in *ppInstanceDefinition.
   
    Returns:
   
      @untitled table
-     0     at the end of the instance defintion table
-     1     instance defintion was successfully read
+     0     at the end of the instance definition table
+     1     instance definition was successfully read
      -1    archive is corrupt at this point
   
    Example:
@@ -3756,7 +3756,7 @@ public:
       user table.
   Returns:
     True if the the user information can be written.
-    False if user informtion should not be written.
+    False if user information should not be written.
   */
   bool BeginWrite3dmUserTable(
     ON_UUID plugin_id,
@@ -3861,7 +3861,7 @@ public:
   //   If it finds one, it reads it and returns the number
   //   of bytes in the archive.  Comparing this number with
   //   the current file position can help detect files that
-  //   have been damaged by loosing sections.
+  //   have been damaged by losing sections.
   //
   // Parameters:
   //   sizeof_archive - [out] number of bytes written to archive
@@ -3887,7 +3887,7 @@ public:
   // Parameters:
   //   typecode - [in] a TCODE_* number from opennurbs_3dm.h
   //   value    - [in] if (typecode&TCODE_SHORT) is nonzero, then
-  //              this is the value to be saved.  Othewise, pass
+  //              this is the value to be saved.  Otherwise, pass
   //              a zero and the EndWrite3dmChunk() call will
   //              store the length of the chunk.
   //
@@ -4015,7 +4015,7 @@ public:
       BeginWriteDictionaryEntry(); 
       write entry definition...
       EndWriteDictionaryEntry();
-    or you may finish writing the dictionay by calling
+    or you may finish writing the dictionary by calling
       EndWriteDictionary();
   */
   bool BeginWriteDictionary(
@@ -4209,7 +4209,7 @@ public:
     and 
     ON::CurrentRuntimeEnvironment() 
     to determine if adjustments need to be made to resources provided
-    by runtime enviroments, like fonts.
+    by runtime environments, like fonts.
   */
   ON::RuntimeEnvironment ArchiveRuntimeEnvironment() const;
 
@@ -4296,7 +4296,7 @@ public:
     If an error is found, a line that begins with the word
     "ERROR" is printed.
   Parameters:
-    text_log - [in] place to print informtion
+    text_log - [in] place to print information
     recursion_depth - [in] simply a counter
         to aid in debugging.
   Returns:
@@ -4370,7 +4370,7 @@ public:
   Description:
     Force Write() to flush any buffered data to physical archive.
   Returns:
-    True if succesful or if there is nothing to flush.  False if
+    True if successful or if there is nothing to flush.  False if
     information could not be flushed.
   */
   virtual bool Flush() = 0;
@@ -4498,7 +4498,7 @@ private:
 protected:
   unsigned int ErrorMessageMask() const;
   /*
-  Paramters:
+  Parameters:
     sizeof_request - [in] 
       value of count parameter passed to virtual Read() function.
     sizeof_read - [in]
@@ -4801,7 +4801,7 @@ private:
 
 private:
   // endian-ness of the cpu reading this file.
-  // 3dm files are alwasy saved with little endian byte order.
+  // 3dm files are always saved with little endian byte order.
   const ON::endian m_endian = ON::Endian();
 
   const ON::archive_mode m_mode = ON::archive_mode::unset_archive_mode;
@@ -4905,7 +4905,7 @@ public:
     component_filter - [out]
       A bitfield that reports which attributes were read.
       If the corresponding component on model_component is locked,
-      the read value is discared.
+      the read value is discarded.
   Returns:
     false: critical failure.
     true: reading can continue.  
@@ -4992,10 +4992,10 @@ public:
   Returns:
     True: (default state)
       Read3dmReferencedComponentIndex() and Write3dmReferencedComponentIndex() will automatically
-      adjust compoents index references so they are valid.
+      adjust components index references so they are valid.
     False: (uncommon)
       Read3dmReferencedComponentIndex() and Write3dmReferencedComponentIndex() will not
-      adjust compoents index references so they are valid.
+      adjust components index references so they are valid.
   */
   bool ReferencedComponentIndexMapping() const;
 
@@ -5006,10 +5006,10 @@ public:
     bEnableReferenceComponentIndexMapping - [in]
     True: (default state)
       Read3dmReferencedComponentIndex() and Write3dmReferencedComponentIndex() will automatically
-      adjust compoents index references so they are valid.
+      adjust components index references so they are valid.
     False: (uncommon)
       Read3dmReferencedComponentIndex() and Write3dmReferencedComponentIndex() will not
-      adjust compoents index references so they are valid. This is only used with the
+      adjust components index references so they are valid. This is only used with the
       component being read or written is not the model but is a copy of one
       in a different model (linked instance definitions being the common situation).
   */
@@ -5068,10 +5068,10 @@ public:
   Returns:
     True: (default state)
       Read3dmReferencedComponentId() and Write3dmReferencedComponentId() will automatically
-      adjust compoents Id references so they are valid.
+      adjust components Id references so they are valid.
     False: (uncommon)
       Read3dmReferencedComponentId() and Write3dmReferencedComponentId() will not
-      adjust compoents Id references so they are valid.
+      adjust components Id references so they are valid.
   */
   bool ReferencedComponentIdMapping() const;
 
@@ -5082,10 +5082,10 @@ public:
     bEnableReferenceComponentIdMapping - [in]
     True: (default state)
       Read3dmReferencedComponentId() and Write3dmReferencedComponentId() will automatically
-      adjust compoents Id references so they are valid.
+      adjust components Id references so they are valid.
     False: (uncommon)
       Read3dmReferencedComponentId() and Write3dmReferencedComponentId() will not
-      adjust compoents Id references so they are valid. This is only used with the
+      adjust components Id references so they are valid. This is only used with the
       component being read or written is not the model but is a copy of one
       in a different model (linked instance definitions being the common situation).
   */
@@ -5470,7 +5470,7 @@ public:
     mode - [in]
     buffer - [in]
   Remarks:
-    If a non-null buffer is specifed, then do not call SetBuffer()
+    If a non-null buffer is specified, then do not call SetBuffer()
   */
   ON_BinaryArchiveBuffer( ON::archive_mode, ON_Buffer* buffer );
 
@@ -5619,7 +5619,7 @@ public:
       If max_sizeof_buffer <= 0, then no buffer size limits are enforced.
     archive_3dm_version  - [in] (0, ,2,3,4,5,50,60,70,...)
       Pass 0 or ON_BinaryArchive::CurrentArchiveVersion() to write the
-      version of opennurbs archives used by lastest version of Rhino.
+      version of opennurbs archives used by latest version of Rhino.
     archive_opennurbs_version - [in]
   */
   ON_Write3dmBufferArchive( 

--- a/opennurbs_archive_manifest.cpp
+++ b/opennurbs_archive_manifest.cpp
@@ -1771,7 +1771,7 @@ ON_ManifestMapImpl* ON_ManifestMap::Impl()
 
 ON_ManifestMap::ON_ManifestMap() ON_NOEXCEPT
 {
-  // explicity implementation to work around a bug in Apple's CLANG
+  // explicitly implementation to work around a bug in Apple's CLANG
 }
 
 ON_ManifestMap::~ON_ManifestMap()
@@ -2836,7 +2836,7 @@ void ON_ComponentManifestItem::Internal_SetDeletedState(
 ////  // Sort the unsorted portion of item_list[] and shuffle it into the sorted portion.
 ////  // The assumption is that this will be faster that simply sorting the entire list
 ////  // again. For some value of sorted_count and count, this will be true. 
-////  // The threshhold ( m_sorted_count <= 32 || unsorted_count > count/2 )
+////  // The threshold ( m_sorted_count <= 32 || unsorted_count > count/2 )
 ////  // is a guess and needs testing and tuning to be optimal.
 ////  else
 ////  {
@@ -2854,7 +2854,7 @@ void ON_ComponentManifestItem::Internal_SetDeletedState(
 ////
 ////    // shuffle sorted portion of a[] and sorted buffer[] together in order.
 ////    ON_ModelComponentIndexChange* e = a + m_sorted_count - 1;      // e = last element in original sorted array.
-////    ON_ModelComponentIndexChange* f = buffer + m_sorted_count - 1; // f = last element in new sorted bufffer[]
+////    ON_ModelComponentIndexChange* f = buffer + m_sorted_count - 1; // f = last element in new sorted buffer[]
 ////    ON_ModelComponentIndexChange* dst = a + count;
 ////    while(dst-- > a)
 ////    {
@@ -3190,7 +3190,7 @@ const ON_ComponentManifestItem_PRIVATE* ON_ComponentManifestTableIndex::SystemIt
 {
   if (m_bIndexedComponent && sytem_item_index < 0 && sytem_item_index > ON_UNSET_INT_INDEX )
   {
-    // The linked list of system items is alwasy short - hash tables and sorting are a waste of time
+    // The linked list of system items is always short - hash tables and sorting are a waste of time
     for (const ON_ComponentManifestItem_PRIVATE* system_item = m_first_system_item; nullptr != system_item; system_item = system_item->m_next)
     {
       if ( system_item->Index() == sytem_item_index )
@@ -4502,7 +4502,7 @@ const class ON_ComponentManifestItem_PRIVATE* ON_ComponentManifestImpl::Previous
 
 ON_ComponentManifest::ON_ComponentManifest() ON_NOEXCEPT
 {
-  // explicity implementation to work around a bug in Apple's CLANG
+  // explicitly implementation to work around a bug in Apple's CLANG
 }
 
 ON_ComponentManifest::~ON_ComponentManifest()

--- a/opennurbs_array.h
+++ b/opennurbs_array.h
@@ -87,7 +87,7 @@ public:
   ON__UINT32 DataCRC(ON__UINT32 current_remainder) const;
 
   // The operator[] does to not check for valid indices.
-  // The caller is responsibile for insuring that 0 <= i < Capacity()
+  // The caller is responsible for insuring that 0 <= i < Capacity()
   T& operator[]( int );
   T& operator[]( unsigned int );
   T& operator[]( ON__INT64 );
@@ -165,7 +165,7 @@ public:
   // successful, then Search() returns -1.  For Search(T) to work 
   // correctly, T must be a simple type.  Use Search(p,compare())
   // for Ts that are structs/classes that contain pointers.  Search()
-  // is only suitable for performing infrequent searchs of small 
+  // is only suitable for performing infrequent searches of small 
   // arrays.  Sort the array and use BinarySearch() for performing
   // efficient searches.
   int Search( const T& ) const;
@@ -182,12 +182,12 @@ public:
 
   //////////
   // BinarySearch( p, compare ) does a fast search of a sorted array
-  // and returns the smallest index "i" of the element that satisifies
+  // and returns the smallest index "i" of the element that satisfies
   // 0==compare(p,&array[i]).  
   //
   // BinarySearch( p, compare, count ) does a fast search of the first
   // count element sorted array and returns the smallest index "i" of 
-  // the element that satisifies 0==compare(p,&array[i]).  The version
+  // the element that satisfies 0==compare(p,&array[i]).  The version
   // that takes a "count" is useful when elements are being appended
   // during a calculation and the appended elements are not sorted.
   //
@@ -287,7 +287,7 @@ public:
   // Count and capacity are not changed.
   void MemSet(unsigned char); 
   
-  // memory managment ////////////////////////////////////////////////////
+  // memory management ////////////////////////////////////////////////////
 
   T* Reserve( size_t );    // increase capacity to at least the requested value
 
@@ -295,7 +295,7 @@ public:
 
   void Destroy();         // onfree any memory and set count and capacity to zero
     
-  // low level memory managment //////////////////////////////////////////
+  // low level memory management //////////////////////////////////////////
 
   // By default, ON_SimpleArray<> uses onrealloc() to manage
   // the dynamic array memory. If you want to use something 
@@ -337,7 +337,7 @@ public:
   /*
   Description:
     Expert user tool to take charge of the memory used by 
-    the dyanmic array.
+    the dynamic array.
   Returns:
      A pointer to the array and zeros out this class.
      The returned pointer is on the heap and must be
@@ -354,7 +354,7 @@ public:
 
   /*
   Description:
-    Expert user tool to set the memory used by the dyanmic array.
+    Expert user tool to set the memory used by the dynamic array.
   Parameters:
     T* pointer - [in]
     int count [in]
@@ -366,7 +366,7 @@ public:
   void SetArray(T*, int, int);
 
 protected:
-  // implimentation //////////////////////////////////////////////////////
+  // implementation //////////////////////////////////////////////////////
   void Move( int /* dest index*/, int /* src index */, int /* element count*/ );
 	T*   m_a;        // pointer to array memory
 	int  m_count;    // 0 <= m_count <= m_capacity
@@ -415,7 +415,7 @@ ON_DLL_TEMPLATE template class ON_CLASS ON_SimpleArray<double*>;
 // besides onrealloc() to manage the array memory, then override
 // ON_ClassArray::Realloc().  In practice this means that if your
 // class has members with back-pointers, then you cannot use
-// it in the defaule ON_ClassArray.  See ON_ObjectArray
+// it in the default ON_ClassArray.  See ON_ObjectArray
 // for an example.
 //
 template <class T> class ON_ClassArray
@@ -461,7 +461,7 @@ public:
   unsigned int SizeOfElement() const; // amount of memory in an m_a[] array element
 
   // The operator[] does to not check for valid indices.
-  // The caller is responsibile for insuring that 0 <= i < Capacity()
+  // The caller is responsible for insuring that 0 <= i < Capacity()
   T& operator[]( int );
   T& operator[]( unsigned int );
   T& operator[]( ON__INT64 );
@@ -538,12 +538,12 @@ public:
 
   //////////
   // BinarySearch( p, compare ) does a fast search of a sorted array
-  // and returns the smallest index "i" of the element that satisifies
+  // and returns the smallest index "i" of the element that satisfies
   // 0==compare(p,&array[i]).
   //
   // BinarySearch( p, compare, count ) does a fast search of the first
   // count element sorted array and returns the smallest index "i" of 
-  // the element that satisifies 0==compare(p,&array[i]).  The version
+  // the element that satisfies 0==compare(p,&array[i]).  The version
   // that takes a "count" is useful when elements are being appended
   // during a calculation and the appended elements are not sorted.
   //
@@ -633,11 +633,11 @@ public:
 
   //////////
   // Destroys all elements and fills them with values
-  // set by the defualt constructor.
+  // set by the default constructor.
   // Count and capacity are not changed.
   void Zero();
 
-  // memory managment /////////////////////////////////////////////////
+  // memory management /////////////////////////////////////////////////
 
   T* Reserve( size_t ); // increase capacity to at least the requested value
 
@@ -645,7 +645,7 @@ public:
 
   void Destroy();      // onfree any memory and set count and capacity to zero
     
-  // low level memory managment ///////////////////////////////////////
+  // low level memory management ///////////////////////////////////////
 
   // By default, ON_ClassArray<> uses onrealloc() to manage
   // the dynamic array memory. If you want to use something 
@@ -703,7 +703,7 @@ public:
 
   /*
   Description:
-    Expert user tool to set the memory used by the dyanmic array.
+    Expert user tool to set the memory used by the dynamic array.
   Parameters:
     T* pointer - [in]
     int count - [in]  0 <= count <= capacity
@@ -717,7 +717,7 @@ public:
   void SetArray(T*, int, int);
 
 protected:
-  // implimentation //////////////////////////////////////////////////////
+  // implementation //////////////////////////////////////////////////////
   void Move( int /* dest index*/, int /* src index */, int /* element count*/ );
   void ConstructDefaultElement(T*);
   void DestroyElement(T&);
@@ -874,9 +874,9 @@ public:
 
   /*
   Description:
-    Makes the uuid list as efficent as possible in both search
+    Makes the uuid list as efficient as possible in both search
     speed and memory usage.  Use Compact() when a uuid list
-    will be in use but is not likely to be modifed.  A list 
+    will be in use but is not likely to be modified.  A list 
     that has been compacted can still be modified.
   */
   void Compact();

--- a/opennurbs_array_defs.h
+++ b/opennurbs_array_defs.h
@@ -966,7 +966,7 @@ void ON_SimpleArray<T>::MemSet( unsigned char value )
   }
 }
 
-// memory managment ////////////////////////////////////////////////////
+// memory management ////////////////////////////////////////////////////
 
 template <class T>
 T* ON_SimpleArray<T>::Reserve( size_t newcap ) 
@@ -988,7 +988,7 @@ void ON_SimpleArray<T>::Destroy()
   SetCapacity( 0 );
 }
 
-// low level memory managment //////////////////////////////////////////
+// low level memory management //////////////////////////////////////////
 
 template <class T>
 void ON_SimpleArray<T>::SetCount( int count ) 
@@ -2057,7 +2057,7 @@ void ON_ClassArray<T>::Zero()
   }
 }
 
-// memory managment ////////////////////////////////////////////////////
+// memory management ////////////////////////////////////////////////////
 
 template <class T>
 T* ON_ClassArray<T>::Reserve( size_t newcap ) 
@@ -2079,7 +2079,7 @@ void ON_ClassArray<T>::Destroy()
   SetCapacity( 0 );
 }
 
-// low level memory managment //////////////////////////////////////////
+// low level memory management //////////////////////////////////////////
 
 template <class T>
 void ON_ClassArray<T>::SetCount( int count ) 

--- a/opennurbs_base64.cpp
+++ b/opennurbs_base64.cpp
@@ -196,7 +196,7 @@ const char* ON_DecodeBase64::Decode(const char* base64str)
       {
         // base64 encoded strings are parsed in groups of 4 characters.
         // When we enter this part of the Decode function, m_status is
-        // either 1 (error occured earlier) or 2.  
+        // either 1 (error occurred earlier) or 2.  
         // A 2 means the previous character we parsed was the 3rd
         // of the group and it was an equal sign.  In this case, the
         // the 4th character in the group must be an equal sign and

--- a/opennurbs_base64.h
+++ b/opennurbs_base64.h
@@ -46,7 +46,7 @@ public:
       base64 encoding calculation.
     callback_context - [in]
       This value is passed as the first argument when calling 
-      callback_function or the virutal Out() function.
+      callback_function or the virtual Out() function.
   Returns:
     True if successful.
   Remarks:
@@ -83,7 +83,7 @@ public:
     calculation. When you reach the end of the unencoded
     stream, call End().
   Returns:
-    true if successful, false if an error occured.
+    true if successful, false if an error occurred.
   */
   bool Begin();
 
@@ -99,7 +99,7 @@ public:
       number of bytes in in_buffer
     in_buffer - [in]
   Returns:
-    true if successful, false if an error occured.
+    true if successful, false if an error occurred.
   */
   bool In(
     ON__UINT64 in_buffer_size,
@@ -146,7 +146,7 @@ public:
     generate one call to the output stream handler with the value
     of out_buffer_size = 4 to 76.
   Returns:
-    true if successful, false if an error occured.
+    true if successful, false if an error occurred.
   */
   bool End();
   
@@ -227,7 +227,7 @@ public:
   // Decode() for every line in the file.  Decode() returns 0 if
   // there is nothing in base64str to decode or if it detects an
   // error that prevents any further decoding.  The function Error()
-  // can be used to determine if an error occured.  Otherwise,
+  // can be used to determine if an error occurred.  Otherwise,
   // Decode() returns a pointer to the location in the string where
   // it stopped decoding because it detected a character, like a null
   // terminator, an end of line character, or any other character
@@ -264,7 +264,7 @@ public:
   // wants to stop further decoding.
   void SetError();
 
-  // Returns true if an error occured during decoding because
+  // Returns true if an error occurred during decoding because
   // invalid input was passed to Decode().
   const bool Error() const;
 

--- a/opennurbs_beam.cpp
+++ b/opennurbs_beam.cpp
@@ -2130,7 +2130,7 @@ bool ON_Extrusion::Transform( const ON_Xform& xform )
     // xform maps plane1 to 
 
     // xform 3 maps the transformed 3d profile to the world 3d plane
-    // that is orthoganal to the transformed axis vector.
+    // that is orthogonal to the transformed axis vector.
     xform3.PlanarProjection(plane1);
 
     // xform4 maps the transformed world 3d profile back to the xy plane
@@ -2170,7 +2170,7 @@ bool ON_Extrusion::Transform( const ON_Xform& xform )
     }
   }
 
-  // start transforming informtion here
+  // start transforming information here
   TransformUserData(xform);
 
   // transform path, up, and miter directions
@@ -2969,7 +2969,7 @@ ON_Brep* ON_Extrusion::BrepForm( ON_Brep* brep, bool bSmoothFaces ) const
       }
       fi.m_face_index = face->m_face_index; 
 
-      // Save vid[] and eid[] informtion so subsequent faces
+      // Save vid[] and eid[] information so subsequent faces
       // are properly joined.
       if ( finfo_index == fi0 )
       {
@@ -3430,7 +3430,7 @@ bool ON_Extrusion::GetSurfaceSize(
     if ( m_profile )
     {
       // A crude over estimate is good enough for file IO 
-      // needs in the public souce code version. When there
+      // needs in the public source code version. When there
       // are multiple profile components, the nurbs_profile_curve
       // will have a whacky control polygon, but it's length will
       // be ok as an estimate.

--- a/opennurbs_beam.h
+++ b/opennurbs_beam.h
@@ -23,7 +23,7 @@ Description:
   2d xy profile to 3d world space.
 Parameters:
   P - [in] start or end of path
-  T - [in] unit tanget to path
+  T - [in] unit tangent to path
   U - [in] unit up vector perpendicular to T
   Normal - [in] optional unit vector with Normal->z > 0 that
      defines the unit normal to the miter plane.
@@ -341,9 +341,9 @@ public:
       * if mesh is null, any existing mesh is deleted and
         nothing is attached.
   Remarks:
-    DEPRECATED. Use ON_Extrusion.m_mesh_cache to managed chached meshes.
+    DEPRECATED. Use ON_Extrusion.m_mesh_cache to managed cached meshes.
   */
-  ON_DEPRECATED_MSG("Use ON_Extrusion.m_mesh_cache to managed chached meshes")
+  ON_DEPRECATED_MSG("Use ON_Extrusion.m_mesh_cache to managed cached meshes")
   bool SetMesh( ON::mesh_type mt, ON_Mesh* mesh );
 
   /*
@@ -362,9 +362,9 @@ public:
     If a mesh of the requested type is not available,
     then null is returned.
   Remarks:
-    DEPRECATED. Use ON_Extrusion.m_mesh_cache to managed chached meshes.
+    DEPRECATED. Use ON_Extrusion.m_mesh_cache to managed cached meshes.
   */
-  ON_DEPRECATED_MSG("Use ON_Extrusion.m_mesh_cache to managed chached meshes")
+  ON_DEPRECATED_MSG("Use ON_Extrusion.m_mesh_cache to managed cached meshes")
   const ON_Mesh* Mesh( ON::mesh_type mt ) const;
 
   /*
@@ -377,9 +377,9 @@ public:
     bDeleteMesh - [in] if true, cached mesh is deleted.
       If false, pointer to cached mesh is just set to null.
   Remarks:
-    DEPRECATED. Use ON_Extrusion.m_mesh_cache to managed chached meshes.
+    DEPRECATED. Use ON_Extrusion.m_mesh_cache to managed cached meshes.
   */
-  ON_DEPRECATED_MSG("Use ON_Extrusion.m_mesh_cache to managed chached meshes")
+  ON_DEPRECATED_MSG("Use ON_Extrusion.m_mesh_cache to managed cached meshes")
   void DestroyMesh( ON::mesh_type mt );
 
   ////////////////////////////////////////////////////////////
@@ -577,7 +577,7 @@ public:
   /*
   Description:
     Set the outer profile of the extrusion.
-  Paramters:
+  Parameters:
     outer_profile - [in] 
       curve in the xy plane or a 2d curve.
     bCap - [in]
@@ -601,7 +601,7 @@ public:
   /*
   Description:
     Add an inner profile.
-  Paramters:
+  Parameters:
     inner_profile - [in]
       closed curve in the xy plane or a 2d curve.
   Returns:
@@ -655,7 +655,7 @@ public:
   int ProfileParameter() const;
 
   /*
-  Paramters:
+  Parameters:
     profile_index - [in]
       0 <= profile_index < ProfileCount().
       The outer profile has index 0.
@@ -668,12 +668,12 @@ public:
   const ON_Curve* Profile(int profile_index) const;
 
   /*
-  Paramters:
+  Parameters:
     profile_index - [in]
       0 <= profile_index < ProfileCount().
       The outer profile has index 0.
     s - [in] ( 0.0 <= s <= 1.0 )
-      A relative parameter controling which priofile
+      A relative parameter controlling which priofile
       is returned. s = 0.0 returns the bottom profile
       and s = 1.0 returns the top profile.
   Returns:
@@ -685,7 +685,7 @@ public:
   ON_Curve* Profile3d(int profile_index, double s ) const;
 
   /*
-  Paramters:
+  Parameters:
     ci - [in]
       component index identifying a 3d extrusion profile curve.
   Returns:
@@ -697,7 +697,7 @@ public:
   ON_Curve* Profile3d( ON_COMPONENT_INDEX ci ) const;
 
   /*
-  Paramters:
+  Parameters:
     ci - [in]
       component index identifying a wall edge curve.
   Returns:
@@ -709,7 +709,7 @@ public:
   ON_Curve* WallEdge( ON_COMPONENT_INDEX ci ) const;
 
   /*
-  Paramters:
+  Parameters:
     ci - [in]
       component index identifying a wall surface.
   Returns:
@@ -721,7 +721,7 @@ public:
   ON_Surface* WallSurface( ON_COMPONENT_INDEX ci ) const;
 
   /*
-  Paramters:
+  Parameters:
     line_curve - [in]
       If null, a line curve will be allocated using new.
   Returns:
@@ -732,14 +732,14 @@ public:
   ON_LineCurve* PathLineCurve(ON_LineCurve* line_curve) const;
 
   /*
-  Paramters:
+  Parameters:
     profile_parameter - [in]
       parameter on profile curve
   Returns:
       -1: if the profile_parameter does not correspond 
           to a point on the profile curve.
     >= 0: index of the profile curve with domain containing
-          this paramter.  When the profile_parameter corresponds
+          this parameter.  When the profile_parameter corresponds
           to the end of one profile and the beginning of the next
           profile, the index of the next profile is returned.
   */
@@ -810,7 +810,7 @@ public:
 
   // path definition:
   //   The line m_path must have length > m_path_length_min.
-  //   The interval m_t must statisfy 0 <= m_t[0] < m_t[1] <= 1.
+  //   The interval m_t must satisfy 0 <= m_t[0] < m_t[1] <= 1.
   //   The extrusion starts at m_path.PointAt(m_t[0]) and ends
   //   at m_path.PointAt(m_t[1]).
   //   The "up" direction m_up is a unit vector that must
@@ -828,12 +828,12 @@ public:
   //   The profile's "y" axis corresponds to m_up.
   //   The point (0,0) is extruded along the m_path line.
   //   If m_profile_count = 1, then m_profile can be any
-  //   type of continous curve.  If m_profile_count > 1,
+  //   type of continuous curve.  If m_profile_count > 1,
   //   then m_profile must be an ON_PolyCurve with
   //   m_profile_count segments, the domain of each segment
   //   must exactly match the polycurve's segment domain,
   //   every segment must be continuous and closed,
-  //   the first segement curve must have counter-clockwise
+  //   the first segment curve must have counter-clockwise
   //   orientation, and the rest must have clockwise 
   //   orientations.
   int m_profile_count;
@@ -879,7 +879,7 @@ public:
     bCapTop - [in] if true, the end at cylinder.m_height[1] will be capped
     extrusion - [in] 
       If the input extrusion pointer is null, one will be allocated on the heap
-      and it is the caller's responsibility to delte it at an appropriate time.
+      and it is the caller's responsibility to delete it at an appropriate time.
       If the input pointer is not null, this extrusion will be used and the same
       pointer will be returned, provided the input is valid.
   Returns:
@@ -924,7 +924,7 @@ public:
     bCapTop - [in] if true, the end at cylinder.m_height[1] will be capped
     extrusion - [in] 
       If the input extrusion pointer is null, one will be allocated on the heap
-      and it is the caller's responsibility to delte it at an appropriate time.
+      and it is the caller's responsibility to delete it at an appropriate time.
       If the input pointer is not null, this extrusion will be used and the same
       pointer will be returned, provided the input is valid.
   Returns:
@@ -977,7 +977,7 @@ public:
       is capped.
     extrusion - [in] 
       If the input extrusion pointer is null, one will be allocated on the heap
-      and it is the caller's responsibility to delte it at an appropriate time.
+      and it is the caller's responsibility to delete it at an appropriate time.
       If the input pointer is not null, this extrusion will be used and the same
       pointer will be returned, provided the input is valid.
   Returns:

--- a/opennurbs_bezier.cpp
+++ b/opennurbs_bezier.cpp
@@ -41,7 +41,7 @@ bool ON_BezierCurve::GetTightBoundingBox(
 {
 
   // The result from ON_GetPointListBoundingBox() is good enough
-  // for file IO needs in the public souce code version.
+  // for file IO needs in the public source code version.
   return ON_GetPointListBoundingBox(
     m_dim,
     m_is_rat, 
@@ -1174,7 +1174,7 @@ bool ON_Mesh::GetTightBoundingBox(
     }
 	}
 
-	// Now just add verticies of the clipped mesh
+	// Now just add vertices of the clipped mesh
 	int vcnt = VertexCount();
 	
 	// n = number of clipping planes.  At most 32 clipping planes are allowed so that this function can use unsigned int
@@ -1272,7 +1272,7 @@ bool ON_Mesh::GetTightBoundingBox(
 						Next = (*xform)*Next;
 					}
 
-					ON_Interval Dom(0.0, 1.0);  // Dom parameterizes the line segment from Last to Next
+					ON_Interval Dom(0.0, 1.0);  // Dom parametrizes the line segment from Last to Next
 					for (int j = 0; j < n && Dom != ON_Interval::EmptyInterval; j++)
 					{
 						unsigned int mask = 1 << (n - 1 - j);
@@ -1960,7 +1960,7 @@ bool ON_BezierCurve::Split(
     
     // deCasteljau
     if (t == 0.5) {
-      // use faster aritmetic for this common case
+      // use faster arithmetic for this common case
       for (i = 1, k = 2*m_order-2; i < k; i++, k--) {
         for (j = i; j < k; j++,j++)  {
           p = b[j-1];
@@ -3005,7 +3005,7 @@ bool ON_BezierSurface::Trim(
    
   if( m_cv_stride[dir] > m_cv_stride[1-dir])
   {
-    // cv's are layed out in the right direction so we can interpret the 
+    // cv's are laid out in the right direction so we can interpret the 
     // them as the cv's of a high dim'l curve.
     crv.m_cv = m_cv;
     crv.m_dim = crv.m_cv_stride = m_cv_stride[dir]; 
@@ -3020,7 +3020,7 @@ bool ON_BezierSurface::Trim(
 
   else
   {
-    // cv's are layed out in the wrong direction so make a curve
+    // cv's are laid out in the wrong direction so make a curve
     // and copy the cv's into the curve.
 
     crv.Create(k*m_order[1-dir],false,m_order[dir]);
@@ -3480,7 +3480,7 @@ bool ON_BezierCurve::EvTangent(
   {
     if ( Ev2Der( t, point, D1, D2 ) )
     {
-      // Use l'Hopital's rule to show that if the unit tanget
+      // Use l'Hopital's rule to show that if the unit tangent
       // exists, the 1rst derivative is zero, and the 2nd
       // derivative is nonzero, then the unit tangent is equal
       // to +/-the unitized 2nd derivative.  The sign is equal

--- a/opennurbs_bezier.h
+++ b/opennurbs_bezier.h
@@ -77,8 +77,8 @@ public:
   //   v_stride - [in] (>=Dimension()) stride to use for the v[] array
   //   v - [out] array of length (der_count+1)*v_stride
   //       curve(t) is returned in (v[0],...,v[m_dim-1]),
-  //       curve'(t) is retuned in (v[v_stride],...,v[v_stride+m_dim-1]),
-  //       curve"(t) is retuned in (v[2*v_stride],...,v[2*v_stride+m_dim-1]),
+  //       curve'(t) is returned in (v[v_stride],...,v[v_stride+m_dim-1]),
+  //       curve"(t) is returned in (v[2*v_stride],...,v[2*v_stride+m_dim-1]),
   //       etc.
   // Returns:
   //   false if unable to evaluate.
@@ -526,8 +526,8 @@ public:
   //   v_stride - [in] (>=m_dim) stride to use for the v[] array
   //   v - [out] array of length (der_count+1)*v_stride
   //       bez(t) is returned in (v[0],...,v[m_dim-1]),
-  //       bez'(t) is retuned in (v[v_stride],...,v[v_stride+m_dim-1]),
-  //       bez"(t) is retuned in (v[2*v_stride],...,v[2*v_stride+m_dim-1]),
+  //       bez'(t) is returned in (v[v_stride],...,v[v_stride+m_dim-1]),
+  //       bez"(t) is returned in (v[2*v_stride],...,v[2*v_stride+m_dim-1]),
   //       etc.
   // Returns:
   //   true if successful
@@ -756,7 +756,7 @@ public:
   //   Get value of a control vertex.
   // Parameters:
   //   cv_index - [in] control vertex index (0 <= cv_index < m_order)
-  //   point - [out] Homogenous value of control vertex.
+  //   point - [out] Homogeneous value of control vertex.
   //      If the bezier is not rational, the weight is 1.
   // Returns:
   //   true if successful.
@@ -858,7 +858,7 @@ public:
 
   /*
   Description:
-    Use a linear fractional tranformation for [0,1] to reparameterize
+    Use a linear fractional transformation for [0,1] to reparameterize
     the bezier.  The locus of the curve is not changed, but the
     parameterization is changed.
   Parameters:
@@ -1457,7 +1457,7 @@ public:
     order1 - [in]
     order2 - [in]
   Returns:
-    True if input was valid and creation succeded.
+    True if input was valid and creation succeeded.
   */
   bool Create(
     int dim,
@@ -1903,7 +1903,7 @@ public:
     Set the world to unit cube map.
   Parameters:
     world2unitcube - [in]
-      Tranformation matrix that maps world coordinates
+      Transformation matrix that maps world coordinates
       to the unit cube (0,1)x(0,1)x(0,1).
   Returns
     True if current bezier volum and input transformation

--- a/opennurbs_bitmap.cpp
+++ b/opennurbs_bitmap.cpp
@@ -765,7 +765,7 @@ bool ON_WindowsBitmapEx::Internal_ReadV5( ON_BinaryArchive& file )
   {
     // Calling ON_WindowsBitmap::ReadCompressed() destroys
     // m_bitmap_filename, so we have to read it into a local
-    // string and make the assigment after calling 
+    // string and make the assignment after calling 
     // ON_WindowsBitmap::ReadCompressed().
     ON_wString bitmap_filename;
     if (rc)

--- a/opennurbs_bitmap.h
+++ b/opennurbs_bitmap.h
@@ -175,7 +175,7 @@ struct ON_WindowsBITMAPINFOHEADER
                                   //           biColors[0] = red mask (0x00FF0000), 
                                   //           biColors[1] = green mask (0x0000FF00), and
                                   //           biColors[2] = blue mask (0x000000FF),
-                                  //           then tese masks are used with each 4-byte
+                                  //           then these masks are used with each 4-byte
                                   //           DWORD in the bitmap array to determine
                                   //           the pixel's relative intensities.                                 //           
                                   //           For other possibilities, see

--- a/opennurbs_bounding_box.cpp
+++ b/opennurbs_bounding_box.cpp
@@ -1580,7 +1580,7 @@ const double* p;
         all_out  &= out;
         if ( some_out && !all_out )
         {
-          // box intersects visble region but is not completely inside it.
+          // box intersects visible region but is not completely inside it.
           return  1;
         }
         bz = m_max.z;
@@ -1666,14 +1666,14 @@ int ON_BoundingBox::GetClosestPoint(
 
 
 
-	// Step 1.  Check for an intersection of the infinte line with the box
+	// Step 1.  Check for an intersection of the infinite line with the box
 	ON_Interval overlap(-ON_DBL_MAX, ON_DBL_MAX);	
 	bool nonempty=true;
   int i;
 	for( i=0;i<3 && nonempty;i++)
 		nonempty = overlap.Intersection(over[i]);
 	
-	if(nonempty){	// infinte line intersects box
+	if(nonempty){	// infinite line intersects box
 		if( overlap.Intersection( ON_Interval(0,1) ) ){
 			// Box & Line segment  intersect
 			if(t0) *t0 = overlap[0];
@@ -1699,7 +1699,7 @@ int ON_BoundingBox::GetClosestPoint(
 		// Project box and line onto coord plane with normal Unit(i).
 
 		if(!overlap.Intersection( over[(i+1)%3], over[(i+2)%3] )){	
-			// Projected line doesnt intersect the projexted box.  
+			// Projected line doesn't intersect the projexted box.  
 			// Find the closest  vertex of the projected box.  
 			ON_3dVector StdUnit(0,0,0);
 			StdUnit[i]=1.0;
@@ -1903,14 +1903,14 @@ bool ON_BoundingBox::GetFarPoint(
 ON_DECL
 bool operator==(const ON_BoundingBox& lhs, const ON_BoundingBox& rhs)
 {
-  // returns false if any coordiate is a nan.
+  // returns false if any coordinate is a nan.
   return (lhs.m_min == rhs.m_min && lhs.m_max == rhs.m_max);
 }
 
 ON_DECL
 bool operator!=( const ON_BoundingBox& lhs, const ON_BoundingBox& rhs )
 {
-  // returns false if any coordiate is a nan.
+  // returns false if any coordinate is a nan.
   if (lhs.m_min != rhs.m_min || lhs.m_max != rhs.m_max)
   {
     return (false == lhs.IsNan() && false == rhs.IsNan());
@@ -3109,7 +3109,7 @@ int ON_BoundingBox::IsDegenerate( double tolerance ) const
   ON_3dVector diag = Diagonal();
   if ( tolerance < 0.0 )
   {
-    // compute scale invarient tolerance
+    // compute scale invariant tolerance
     tolerance = diag.MaximumCoordinate()*ON_SQRT_EPSILON;
   }
   int rc = 0;

--- a/opennurbs_bounding_box.h
+++ b/opennurbs_bounding_box.h
@@ -50,7 +50,7 @@ public:
   // OBSOLETE
   void Destroy(); // set this = ON_BoundingBox::EmptyBoundingBox
 
-  // operator[] returns min if index <= 0 and max if indes >= 1
+  // operator[] returns min if index <= 0 and max if index >= 1
   ON_3dPoint& operator[](int);
   const ON_3dPoint& operator[](int) const;
 
@@ -107,7 +107,7 @@ public:
   Parameters:
     tolerance - [in] Distances <= tolerance will be considered
         to be zero.  If tolerance is negative (default), then
-        a scale invarient tolerance is used.
+        a scale invariant tolerance is used.
   Returns:
     @untitled table
     0     box is not degenerate
@@ -699,7 +699,7 @@ public:
     false - hash was not in the cache.
   Remarks:
     If the hash values you are using are correctly computed and include
-    all information that the bouding box depends on, then
+    all information that the bounding box depends on, then
     you never need to remove bounding boxes. Unused ones will get
     removed as new ones are added.
   */
@@ -712,7 +712,7 @@ public:
     Removes all bounding boxes.
   Remarks:
     If the hash values you are using are correctly computed and include
-    all information that the bouding box depends on, then
+    all information that the bounding box depends on, then
     you never need to remove bounding boxes. Unused ones will get
     removed as new ones are added.
     If the hash does not include all information required to compute

--- a/opennurbs_box.cpp
+++ b/opennurbs_box.cpp
@@ -62,7 +62,7 @@ int ON_Box::IsDegenerate( double tolerance ) const
     const ON_3dVector diag(dx.Length(),dy.Length(),dz.Length());
     if ( !ON_IsValid(tolerance) || tolerance < 0.0 )
     {
-      // compute scale invarient tolerance
+      // compute scale invariant tolerance
       tolerance = diag.MaximumCoordinate()*ON_SQRT_EPSILON;
     }
     if ( diag.x <= tolerance )

--- a/opennurbs_box.h
+++ b/opennurbs_box.h
@@ -99,7 +99,7 @@ public:
   Parameters:
     tolerance - [in] Distances <= tolerance will be considered
         to be zero.  If tolerance is negative (default), then
-        a scale invarient tolerance is used.
+        a scale invariant tolerance is used.
   Returns:
     @untitled table
     0     box is not degenerate

--- a/opennurbs_brep.cpp
+++ b/opennurbs_brep.cpp
@@ -1585,7 +1585,7 @@ bool ON_Brep::Transform( const ON_Xform& xform )
     //   bailed down to a unit system change from a 
     //   "long" unit to mm made a valid brep invalid
     //   because the edge tolerances were too small.
-    //   This fix does ot handle non-uniform scaling.
+    //   This fix does not handle non-uniform scaling.
     //   In the case of a non-uniform scale, the edge
     //   tolerance should be recalculated.
     if (edge.m_tolerance > 0.0 && uniform_scale > 0.0 && uniform_scale != 1.0)
@@ -5564,7 +5564,7 @@ bool ON_Brep::IsValid( ON_TextLog* text_log ) const
       // This is permitted. The are set when extensive
       // trim-edge parameter correspondence is needed.
       // Meshing is an example of a calculation that sets
-      // the "e" paramters.
+      // the "e" parameters.
       continue;
     }
 
@@ -5944,11 +5944,11 @@ int ON_Brep::NextEdge(int ei, int endi, int* next_endi ) const
   for ( vei = 0; vertex.m_ei[vei] != ei && vei < edge_count; vei++)
     ;/* empty for*/
   if ( edge.m_vi[0] == edge.m_vi[1]  && endi ) {
-    // get next occurance of edge index
+    // get next occurrence of edge index
     //
     // On closed edges, edge.m_vi[0] = edge.m_vi[1] and edge.edge_index 
-    // appears TWICE in vertex.m_ei[].  The first occurance of edge.edge_index
-    // in vertex.m_ei[] corresponds to edge.m_vi[0].  The second occurance
+    // appears TWICE in vertex.m_ei[].  The first occurrence of edge.edge_index
+    // in vertex.m_ei[] corresponds to edge.m_vi[0].  The second occurrence
     // of edge.edge_index in vertex.m_ei[] corresponds to edge.m_vi[1].
     vei++;
     while ( vei < edge_count && vertex.m_ei[vei] != ei )
@@ -5988,11 +5988,11 @@ int ON_Brep::PrevEdge(int ei, int endi, int* prev_endi ) const
   for ( vei = 0; vertex.m_ei[vei] != ei && vei < edge_count; vei++)
     ;/* empty for*/
   if ( edge.m_vi[0] == edge.m_vi[1] && endi ) {
-    // get next occurance of edge index
+    // get next occurrence of edge index
     //
     // On closed edges, edge.m_vi[0] = edge.m_vi[1] and edge.edge_index 
-    // appears TWICE in vertex.m_ei[].  The first occurance of edge.edge_index
-    // in vertex.m_ei[] corresponds to edge.m_vi[0].  The second occurance
+    // appears TWICE in vertex.m_ei[].  The first occurrence of edge.edge_index
+    // in vertex.m_ei[] corresponds to edge.m_vi[0].  The second occurrence
     // of edge.edge_index in vertex.m_ei[] corresponds to edge.m_vi[1].
     vei++;
     while ( vei < edge_count && vertex.m_ei[vei] != ei )
@@ -6319,7 +6319,7 @@ bool ON_Brep::GetTightBoundingBox(ON_BoundingBox& tight_bbox, bool bGrowBox, con
 
   ON_BoundingBox local_bbox;
 
-  // Test vertexes first, this will quickly give us a base bbox to work with. 
+  // Test vertices first, this will quickly give us a base bbox to work with. 
   int vct = m_V.Count();
   for (int i = 0; vct > i; i++)
   {
@@ -7949,7 +7949,7 @@ ON_Brep::SetEdgeTolerance( ON_BrepEdge& edge, bool bLazySet ) const
     {
       edge.m_tolerance = ON_UNSET_VALUE;
       // TL_Brep::SetEdgeTolerance overrides ON_Brep::SetEdgeTolerance
-      // and sets teh tolerance correctly.
+      // and sets the tolerance correctly.
     }
   }
   return (edge.m_tolerance >= 0.0) ? true : false;
@@ -9808,7 +9808,7 @@ bool ON_Brep::CullUnusedTrims()
         }
       }
 
-      // remap loop.m_ti[] indicies
+      // remap loop.m_ti[] indices
       for ( li = 0; li < lcount; li++ ) {
         ON_BrepLoop& loop = m_L[li];
         ltcnt = loop.m_ti.Count();
@@ -9830,7 +9830,7 @@ bool ON_Brep::CullUnusedTrims()
         }
       }
 
-      // remap edge.m_ti[] indicies
+      // remap edge.m_ti[] indices
       for ( ei = 0; ei < ecount; ei++ ) {
         ON_BrepEdge& edge = m_E[ei];
         etcnt = edge.m_ti.Count();
@@ -10744,7 +10744,7 @@ ON_BrepEdge* ON_Brep::CombineContiguousEdges(
     loop.m_ti.Remove( loop_lti1[eti] );
 
 		//GBA 1/29/03 Fixes TRR#9233.  Removing an item from loop.m_ti
-		//will cause loop indicies stored in loop_lti0[] and loop_lti1[]
+		//will cause loop indices stored in loop_lti0[] and loop_lti1[]
 		//to be wrong. So they must be reindexed
 		int ri = loop_lti1[eti];			// removed index
     int li = loop.m_loop_index;
@@ -11445,7 +11445,7 @@ ON_BrepTrim& ON_Brep::NewCurveOnFace( ON_BrepFace& face, ON_BrepEdge& edge, bool
 //of the closest point to Points[i], and let di be the distance to the chord.
 //Transform Points so that Points[0] = P0, Points[last] = P1, 
 //and the new ti and di remain the same.  Don't do anything if the chord is short 
-//relative to the cummulative dist between consecutive points on input.
+//relative to the cumulative dist between consecutive points on input.
 
 static bool AdjustPointListAlongChord(ON_3dPointArray& Points, 
                                       const ON_3dPoint& P0, 

--- a/opennurbs_brep.h
+++ b/opennurbs_brep.h
@@ -1195,7 +1195,7 @@ public:
     grid packs, star packs and singleton packs.
     A brep "grid pack" comes from a rectangular grid of subd quads. A grid pack of brep faces can
     be converted into a single larger trivially trimmed brep face.
-    A brep "star pack" of brep faces comes from a singel subd n-gon (n = 3, 5 or more). The star pack
+    A brep "star pack" of brep faces comes from a single subd n-gon (n = 3, 5 or more). The star pack
     will have n faces with a star center vertex and shared edges radiating from  the star center.
     A brep "singleton" pack comes from a single subd quad that could not be grouped into a larger
     subd quad grid pack.
@@ -1226,7 +1226,7 @@ public:
     grid packs, star packs and singleton packs.
     A brep "grid pack" comes from a rectangular grid of subd quads. A grid pack of brep faces can
     be converted into a single larger trivially trimmed brep face.
-    A brep "star pack" of brep faces comes from a singel subd n-gon (n = 3, 5 or more). The star pack
+    A brep "star pack" of brep faces comes from a single subd n-gon (n = 3, 5 or more). The star pack
     will have n faces with a star center vertex and shared edges radiating from  the star center.
     A brep "singleton" pack comes from a single subd quad that could not be grouped into a larger
     subd quad grid pack.
@@ -4125,7 +4125,7 @@ protected:
   
 
 public:
-  // The ON_Brep code increments ON_Brep::ErrorCount everytime something
+  // The ON_Brep code increments ON_Brep::ErrorCount every time something
   // unexpected happens. This is useful for debugging.
   static unsigned int ErrorCount;
 };
@@ -4421,7 +4421,7 @@ Parameters:
   pBrep - [in] if not nullptr, this brep will be used and
                returned.
 Returns:
-  An ON_Brep representation of the trimmed plane with a singe face.
+  An ON_Brep representation of the trimmed plane with a single face.
 See Also:
   ON_Brep::NewPlanarFaceLoop()
 */

--- a/opennurbs_brep_extrude.cpp
+++ b/opennurbs_brep_extrude.cpp
@@ -255,7 +255,7 @@ bool ON_BrepExtrudeHelper_MakeTopLoop(
   // vertex brep.m_V[brep.m_T[bottom_loop.m_ti[lti]].m_vi[0]].
   // Set top_vertex_index[lti] = index of edge above 
   // edge of brep.m_T[bottom_loop.m_ti[lti]].
-  // This informtion is needed for singular and seam trims.
+  // This information is needed for singular and seam trims.
   ON_SimpleArray<int> top_vertex_index(loop_trim_count);
   ON_SimpleArray<int> top_edge_index(loop_trim_count);
   ON_SimpleArray<bool> top_trim_bRev3d(loop_trim_count);

--- a/opennurbs_brep_io.cpp
+++ b/opennurbs_brep_io.cpp
@@ -796,7 +796,7 @@ bool ON_Brep::Write( ON_BinaryArchive& file ) const
     }
     else if (minor_version >= 3)
     {
-      // begin chunk verson 3.3
+      // begin chunk version 3.3
 
       // region topology chunk added
       if (!file.BeginWrite3dmAnonymousChunk(1))
@@ -1056,7 +1056,7 @@ bool ON_Brep::Read( ON_BinaryArchive& file )
         m_is_solid = 0;
       if (rc && minor_version >= 3)
       {
-        // begin chunk verson 3.3
+        // begin chunk version 3.3
 
         // region topology chunk added
         int region_topology_chunk_version = 0;
@@ -1103,8 +1103,8 @@ bool ON_Brep::Read( ON_BinaryArchive& file )
 
   // GBA 3-Sept-20 RH-60112
   // In V6 and earlier bounding boxes of faces were bounding box of underlying surface.
-  // This can result in enourmous boxes which mess up make2d
-  // In V7 bounding boxes use the trim pbox resulting in resonable boxes.
+  // This can result in enormous boxes which mess up make2d
+  // In V7 bounding boxes use the trim pbox resulting in reasonable boxes.
   if (file.Archive3dmVersion() < 70 || file.ArchiveOpenNURBSVersion() < 2382395020)
   {
     if (!m_bbox.IsEmpty())
@@ -1396,7 +1396,7 @@ bool ON_Brep::ReadOld200( ON_BinaryArchive& file, int minor_version )
 
 bool ON_Brep::ReadOld100( ON_BinaryArchive& file )
 {
-  // b-rep was written by old Rhino I/O tookit
+  // b-rep was written by old Rhino I/O toolkit
   int sz, i;
 
   // 2d curve geometry
@@ -1409,7 +1409,7 @@ bool ON_Brep::ReadOld100( ON_BinaryArchive& file )
     m_C2.Append( Read100_BrepCurve( file ) );
   }
 
-  // 3d curve geomery
+  // 3d curve geometry
   file.ReadInt( &sz );
   if ( sz < 1 ) {
     return false;
@@ -1612,13 +1612,13 @@ bool ON_Brep::ReadOld101( ON_BinaryArchive& file )
 
 ON_Curve* ON_Brep::Read100_BrepCurve( ON_BinaryArchive& ) const
 {
-  // TODO - look at old Rhino I/O tookit code and read b-rep curves
+  // TODO - look at old Rhino I/O toolkit code and read b-rep curves
   return nullptr;
 }
 
 ON_Surface* ON_Brep::Read100_BrepSurface( ON_BinaryArchive& ) const
 {
-  // TODO - look at old Rhino I/O tookit code and read b-rep surfaces
+  // TODO - look at old Rhino I/O toolkit code and read b-rep surfaces
   return nullptr;
 }
 

--- a/opennurbs_brep_isvalid.cpp
+++ b/opennurbs_brep_isvalid.cpp
@@ -446,7 +446,7 @@ ON_Brep::IsValidEdgeTopology( int edge_index, ON_TextLog* text_log ) const
     {
       text_log->Print("brep.m_E[%d] edge is not valid.\n",edge_index);
       text_log->PushIndent();
-      text_log->Print("m_C3[%d].Domain() = (%g,%g) does not inlclude m_E[%d].ProxyCurveDomain() = (%g,%g) is not increasing\n",
+      text_log->Print("m_C3[%d].Domain() = (%g,%g) does not include m_E[%d].ProxyCurveDomain() = (%g,%g) is not increasing\n",
                       c3i,c3_dom[0],c3_dom[1],edge_index,proxy_sub_dom[0],proxy_sub_dom[1]);
       text_log->PopIndent();
     }

--- a/opennurbs_brep_region.cpp
+++ b/opennurbs_brep_region.cpp
@@ -164,7 +164,7 @@ bool ON_BrepRegionTopology::Transform( const ON_Xform& xform)
 
 bool ON_V5_BrepRegionTopologyUserData::Write(ON_BinaryArchive& binary_archive) const
 {
-  // m_write_region_topology_ptr is never nullptr when this fuction is called
+  // m_write_region_topology_ptr is never nullptr when this function is called
   return 
     (nullptr == m_write_region_topology_ptr)
     ?
@@ -865,7 +865,7 @@ bool ON_BrepRegionTopology::IsValid( ON_TextLog* text_log) const
 
   if ( infinite_region_index < 0 )
   {
-    PRINT_MSG("ON_BrepRegionTopology::m_R[] has no infinte region\n");
+    PRINT_MSG("ON_BrepRegionTopology::m_R[] has no infinite region\n");
     return false;
   }
 
@@ -1053,7 +1053,7 @@ ON_Brep* ON_Brep::SubBrep(
 {
   class LeakStopper : public ON_Workspace
   {
-    // If an error occures during construction,
+    // If an error occurs during construction,
     // this class cleans up sub_brep in an
     // appropriate fashion.
   public:

--- a/opennurbs_brep_tools.cpp
+++ b/opennurbs_brep_tools.cpp
@@ -30,7 +30,7 @@
 static
 const ON_BrepEdge* FindLinearEdge( const ON_Brep& brep, int vi0, int vi1 )
 {
-  // searchs for a linear edge connecting the vertices
+  // searches for a linear edge connecting the vertices
   // brep.m_V[vi0] and brep.m_V[vi1].
   if ( vi0 < 0 || vi0 >= brep.m_V.Count() )
     return nullptr;
@@ -540,21 +540,21 @@ ON_BrepLoop* ON_Brep::NewOuterLoop(
       int vi1 = edge_vi[1-bRev3d[i]];
       if ( vi0 < 0 || vi1 < 0 )
       {
-        ON_ERROR("ON_Brep::NewFace(ON_Surface*,...) error: Bad edge vertex informtion.");
+        ON_ERROR("ON_Brep::NewFace(ON_Surface*,...) error: Bad edge vertex information.");
         return 0;
       }
       if ( vid[i] == -1 )
         vid[i] = vi0;
       else if ( vid[i] != vi0 )
       {
-        ON_ERROR("ON_Brep::NewFace(ON_Surface*,...) error: Edge and vertex informtion do not match.");
+        ON_ERROR("ON_Brep::NewFace(ON_Surface*,...) error: Edge and vertex information do not match.");
         return 0;
       }
       if ( vid[(i+1)%4] == -1 )
         vid[(i+1)%4] = vi1;
       else if ( vid[(i+1)%4] != vi1 )
       {
-        ON_ERROR("ON_Brep::NewFace(ON_Surface*,...) error: Edge and vertex informtion do not match.");
+        ON_ERROR("ON_Brep::NewFace(ON_Surface*,...) error: Edge and vertex information do not match.");
         return 0;
       }
     }
@@ -1900,7 +1900,7 @@ ON_Brep* ON_BrepFromMesh(
     ON_Surface::ISO tri_iso[3] = {ON_Surface::S_iso,ON_Surface::E_iso,ON_Surface::not_iso};
 
     // May 1, 2012 Tim Fix for RR 104209
-    // Use double precision vertexes from the mesh if they exist
+    // Use double precision vertices from the mesh if they exist
     const ON_3dPointArray* pDPV = 0;
     if (mesh_topology.m_mesh->HasDoublePrecisionVertices())
       pDPV = &mesh_topology.m_mesh->DoublePrecisionVertices();
@@ -1911,7 +1911,7 @@ ON_Brep* ON_BrepFromMesh(
       ON_3dPoint pt;
 
       // May 1, 2012 Tim Fix for RR 104209
-      // Use double precision vertexes from the mesh if they exist
+      // Use double precision vertices from the mesh if they exist
       const ON_MeshTopologyVertex& topvert = mesh_topology.m_topv[vi];
       if (0 != pDPV)
         pt = *pDPV->At(topvert.m_vi[0]);
@@ -2557,7 +2557,7 @@ bool ON_Brep::RemoveSlits(ON_BrepLoop& L)
   while (rval && FoundSlitPair(*Loop(li), &lti0, &lti1)){ 
     ON_BrepLoop* newloop = nullptr;
 		// Warning- This can add a loop and or face causing
-		//  reallocation of arrays so refernces (like L) are
+		//  reallocation of arrays so references (like L) are
 		//  no longer valid.
     rval = RemoveSlitPair(*this, li, lti0, lti1, newloop);
     rc = rc || rval;

--- a/opennurbs_calculator.cpp
+++ b/opennurbs_calculator.cpp
@@ -41,8 +41,8 @@ public:
 
   enum
   {
-    // op_stack_capacity is large to accomodate expressions
-    // with nested parenthises. A stack of four elements 
+    // op_stack_capacity is large to accommodate expressions
+    // with nested parentheses. A stack of four elements 
     // suffices to parse expressions that do not not contain
     // nested parentheses.
     op_stack_capacity = 62
@@ -770,7 +770,7 @@ bool ON_ArithmeticCalculatorImplementation::AppendArithmeticOperator(
     }
 
     // specifying an explicit aritimetic operator clears the
-    // potential for implied multiplication that occures after
+    // potential for implied multiplication that occurs after
     // a "symbol" value or right parenthesis.
     m_bPendingImpliedMultiplication = false;
 

--- a/opennurbs_circle.h
+++ b/opennurbs_circle.h
@@ -21,7 +21,7 @@ class ON_NurbsCurve;
 
 /*
 Description:
-	ON_Circle is a circle in 3d.  The cirle is represented by a radius and an 
+	ON_Circle is a circle in 3d.  The circle is represented by a radius and an 
 	orthonormal frame	of the plane containing the circle, with origin at the center.
 
 	An Is_Valid() circle has positive radius and an Is_ Valid() plane defining the frame.

--- a/opennurbs_color.h
+++ b/opennurbs_color.h
@@ -319,7 +319,7 @@ public:
   Parameters:
     format - [in]
     separator - [in]
-    character to sepearate numbers (unicode code point - UTF-16 surrogate pairs not supported)
+    character to separate numbers (unicode code point - UTF-16 surrogate pairs not supported)
       pass 0 for default.
     bFormatUnsetColor - [in]
       If true, ON_Color::UnsetColor will return "UnsetColor". Otherwise ON_Color::UnsetColor will return the empty string.
@@ -338,7 +338,7 @@ public:
     format - [in]
       If format is ON_Color::TextFormat::Unset, then text_log.ColorFormat is used.
     separator - [in]
-    character to sepearate numbers (unicode code point - UTF-16 surrogate pairs not supported)
+    character to separate numbers (unicode code point - UTF-16 surrogate pairs not supported)
       pass 0 for default.
     bFormatUnsetColor - [in]
       If true, ON_Color::UnsetColor will return "UnsetColor". Otherwise ON_Color::UnsetColor will return the empty string.

--- a/opennurbs_compress.cpp
+++ b/opennurbs_compress.cpp
@@ -123,7 +123,7 @@ bool ON_CompressStream::In( ON__UINT64 size, const void* uncompressed_buffer )
   bool rc = false;
   ON__UINT32 deflate_output_count;
 
-  // counter prevents infinte loops if there is a bug in zlib return codes.
+  // counter prevents infinite loops if there is a bug in zlib return codes.
   for( int counter = 512; counter > 0; counter-- )
   {
     // Call zlib's deflate function.  It can either process
@@ -138,7 +138,7 @@ bool ON_CompressStream::In( ON__UINT64 size, const void* uncompressed_buffer )
     {
       if ( size <= 0 )
       {
-        // finshed with uncompressed input
+        // finished with uncompressed input
         break;
       }
       // submit a portion of uncompressed_buffer to zlib
@@ -232,7 +232,7 @@ bool ON_CompressStream::End()
   bool rc = false;
   ON__UINT32 deflate_output_count;
 
-  // counter prevents infinte loops if there is a bug in zlib return codes.
+  // counter prevents infinite loops if there is a bug in zlib return codes.
   for( int counter = 512; counter > 0; counter-- )
   {
     // provide storage for compressed stream output
@@ -441,7 +441,7 @@ bool ON_UncompressStream::In( ON__UINT64 size, const void* compressed_buffer )
   bool rc = false;
   ON__UINT32 inflate_output_count;
 
-  // counter prevents infinte loops if there is a bug in zlib return codes.
+  // counter prevents infinite loops if there is a bug in zlib return codes.
   for( int counter = 512; counter > 0; counter-- )
   {
     // Call zlib's inflate function.  It can process
@@ -456,7 +456,7 @@ bool ON_UncompressStream::In( ON__UINT64 size, const void* compressed_buffer )
     {
       if ( size <= 0 )
       {
-        // finshed with compressed input
+        // finished with compressed input
         break;
       }
       // submit a portion of compressed_buffer to zlib
@@ -550,7 +550,7 @@ bool ON_UncompressStream::End()
   bool rc = false;
   ON__UINT32 inflate_output_count;
 
-  // counter prevents infinte loops if there is a bug in zlib return codes.
+  // counter prevents infinite loops if there is a bug in zlib return codes.
   for( int counter = 512; counter > 0; counter-- )
   {
     // provide storage for compressed stream output

--- a/opennurbs_compress.h
+++ b/opennurbs_compress.h
@@ -46,7 +46,7 @@ public:
       compression calculation.
     callback_context - [in]
       This value is passed as the first argument when calling 
-      callback_function or the virutal Out() function.
+      callback_function or the virtual Out() function.
   Returns:
     True if successful.
   Remarks:
@@ -83,7 +83,7 @@ public:
     When you reach the end of the uncompressed stream, call 
     End().
   Returns:
-    true if successful, false if an error occured.
+    true if successful, false if an error occurred.
   */
   bool Begin();
 
@@ -97,7 +97,7 @@ public:
       number of bytes in in_buffer
     in_buffer - [in]
   Returns:
-    true if successful, false if an error occured.
+    true if successful, false if an error occurred.
   */
   bool In( 
     ON__UINT64 in_buffer_size, 
@@ -118,7 +118,7 @@ public:
     In general, it is probably going to be easier to test and debug
     your code if you ignore the callback_context parameter and add 
     a member variable to your derived class to make additional
-    information accessable to your Out function.
+    information accessible to your Out function.
   */
   virtual bool Out( 
     void* callback_context, 
@@ -132,7 +132,7 @@ public:
     Calling End() may generate zero or more 
     calls to the output stream handler.
   Returns:
-    true if successful, false if an error occured.
+    true if successful, false if an error occurred.
   */
   bool End();
 
@@ -223,7 +223,7 @@ public:
       uncompression calculation.
     callback_context - [in]
       This value is passed as the first argument when calling 
-      callback_function or the virutal Out() function.
+      callback_function or the virtual Out() function.
   Returns:
     True if successful.
   Remarks:
@@ -260,7 +260,7 @@ public:
     When you reach the end of the compressed stream, call 
     End().
   Returns:
-    true if successful, false if an error occured.
+    true if successful, false if an error occurred.
   */
   bool Begin();
 
@@ -274,7 +274,7 @@ public:
       number of bytes in in_buffer
     in_buffer - [in]
   Returns:
-    true if successful, false if an error occured.
+    true if successful, false if an error occurred.
   */
   bool In(
     ON__UINT64 in_buffer_size,
@@ -295,7 +295,7 @@ public:
     In general, it is probably going to be easier to test and debug
     your code if you ignore the callback_context parameter and add 
     a member variable to your derived class to make additional
-    information accessable to your Out function.
+    information accessible to your Out function.
   */
   virtual bool Out( 
     void* callback_context, 
@@ -309,7 +309,7 @@ public:
     Calling End() may generate zero or more 
     calls to the output stream handler.
   Returns:
-    true if successful, false if an error occured.
+    true if successful, false if an error occurred.
   */
   bool End();
 
@@ -451,7 +451,7 @@ public:
 
   /*
   Description:
-  Destroy the current informtion in the ON_CompressedBuffer
+  Destroy the current information in the ON_CompressedBuffer
   so the class can be reused.
   */
   void Destroy();

--- a/opennurbs_compstat.cpp
+++ b/opennurbs_compstat.cpp
@@ -269,7 +269,7 @@ unsigned int ON_ComponentStatus::ClearStates(
   {
     // If input was selected and highlighted,
     // and output is not selected,
-    // and hightlight and not explictily cleared,
+    // and highlight and not explicitly cleared,
     // then preserve highlight sync by auto-clearing highlight.
     if ( 0 == (SELECTED_MASK & s1)
       && 0 != (SELECTED_MASK & m_status_flags)
@@ -277,7 +277,7 @@ unsigned int ON_ComponentStatus::ClearStates(
       && 0 != (HIGHLIGHTED_BIT & s1)
       )
     { 
-      // Input was selected and hightlighted,
+      // Input was selected and highlighted,
       // output is not selected.
       // Clear highlight automatically.
       s1 &= ~HIGHLIGHTED_BIT;

--- a/opennurbs_compstat.h
+++ b/opennurbs_compstat.h
@@ -123,13 +123,13 @@ public:
   Description:
     A tool for adding a status check filter. This tool pays attention to RuntimeMark().
 
-  Paramters:
+  Parameters:
     candidate - [in]
     pass_bits - [in]
     fail_bits - [in]
 
   Returns:
-    Checking is perfomed in the folloing order and every bit, include the RuntimeMark() bit, are tested.
+    Checking is performed in the following order and every bit, include the RuntimeMark() bit, are tested.
 
     First:
     If ON_ComponentStatus::LogicalAnd(candidate,status_pass) has any set bits,
@@ -441,7 +441,7 @@ public:
 
   //////////////////////////////////////////////////////////////////////////
   //
-  // Checking multiple state values efficently
+  // Checking multiple state values efficiently
   //
 
   bool operator==(const ON_ComponentStatus&) const;
@@ -527,7 +527,7 @@ private:
 
 
 /*
-ON_AggregateComponentStatus is obsolte.
+ON_AggregateComponentStatus is obsolete.
 It exists because the virtual interface on ON_Object and the member on ON_Brep
 cannot be changed without breakky the pubic C++ SDK.
 Whenever possible, use ON_AggregateComponentStatusEx.
@@ -550,7 +550,7 @@ public:
   Description:
     Sets all states to clear.  
     Marks status as current.
-    Does not change compoent count
+    Does not change component count
   Returns
     true if successful.
     false if information is not current and ClearAllStates() failed.
@@ -561,7 +561,7 @@ public:
   Description:
     Sets all states specified by states_to_clear to clear.  
     Does not change current mark.
-    Does not change compoent count.
+    Does not change component count.
   Returns
     true if successful.
     false if information is not current and ClearAggregateStatus() failed.
@@ -625,13 +625,13 @@ public:
 
   /*
   Returns:
-    Number of compoents that are selected or persistently selected.
+    Number of components that are selected or persistently selected.
   */
   unsigned int SelectedCount() const;
 
   /*
   Returns:
-    Number of compoents that are persistently selected.
+    Number of components that are persistently selected.
   */
   unsigned int SelectedPersistentCount() const;
 
@@ -702,7 +702,7 @@ public:
   Description:
     Sets all states to clear.
     Marks status as current.
-    Does not change compoent count
+    Does not change component count
   Returns
     true if successful.
     false if information is not current and ClearAllStates() failed.
@@ -713,7 +713,7 @@ public:
   Description:
     Sets all states specified by states_to_clear to clear.
     Does not change current mark.
-    Does not change compoent count.
+    Does not change component count.
   Returns
     true if successful.
     false if information is not current and ClearAggregateStatus() failed.
@@ -777,13 +777,13 @@ public:
 
   /*
   Returns:
-    Number of compoents that are selected or persistently selected.
+    Number of components that are selected or persistently selected.
   */
   unsigned int SelectedCount() const;
 
   /*
   Returns:
-    Number of compoents that are persistently selected.
+    Number of components that are persistently selected.
   */
   unsigned int SelectedPersistentCount() const;
 
@@ -841,7 +841,7 @@ public:
   Description:
     Add x to the list. The expert caller is certain that x is not already in the list.
     For large lists, using this function when appropriate, can result in substantial
-    speed improvments.
+    speed improvements.
   Parameters:
     x - [in]
       A value that is known to not be in the list.

--- a/opennurbs_convex_poly.cpp
+++ b/opennurbs_convex_poly.cpp
@@ -38,7 +38,7 @@ ON_3dSimplex::ON_3dSimplex(const ON_3dPoint& a, const ON_3dPoint& b, const ON_3d
 
 int ON_3dSimplex::Count() const { return m_n; };
 
-bool ON_3dSimplex::IsValid(double eps) const		// true if the Verticies are affinely independent
+bool ON_3dSimplex::IsValid(double eps) const		// true if the Vertices are affinely independent
 {
   bool rc = true;
   if (m_n >= 2)
@@ -251,7 +251,7 @@ ON_3dVector ON_3dSimplex::Edge(int e0, int e1) const
 
 
 /*
-    This is a carefull implementation of cross product that tries to get an accurate result
+    This is a careful implementation of cross product that tries to get an accurate result
 */
 ON_3dVector ON_CrossProductwCare(const ON_3dVector& A, ON_3dVector& B)
 {
@@ -417,7 +417,7 @@ bool ON_3dSimplex::Closest2plex(ON_4dPoint& Bary) const
     for (int i = 0; i < 3; i++)
       Planar[i] = Vertex(i) - P3;
 
-    // Finding the barycentric coordintes of the origin will guild the rest of the algorithm
+    // Finding the barycentric coordinates of the origin will guild the rest of the algorithm
     // We simplify this by projecting to Not J plane
 
     double DetM = 0.0;
@@ -695,7 +695,7 @@ double ON_ConvexHullRef::MaximumCoordinate() const
   return ON_MaximumCoordinate(m_v, 3, m_is_rat, m_n);
 }
 
-int ON_ConvexHullPoint2::AppendVertex(const ON_3dPoint& P) // return index of new vertex.  must set Adjacent Indicies.
+int ON_ConvexHullPoint2::AppendVertex(const ON_3dPoint& P) // return index of new vertex.  must set Adjacent Indices.
 {
   m_Vert.Append(P);
   Ref.Initialize(m_Vert, m_Vert.Count());
@@ -729,8 +729,8 @@ bool ON_ConvexPoly::GetClosestPointSeeded(ON_3dPoint P0,
   return rc;
 }
 
-// MatchingSupport(A, B) retuns a positive number if
-//  A[i]<0 iff B[i]<0 and at least one coordinate pair has valid indicies A[i]>=0 and B[i]>=0.
+// MatchingSupport(A, B) returns a positive number if
+//  A[i]<0 iff B[i]<0 and at least one coordinate pair has valid indices A[i]>=0 and B[i]>=0.
 static int MatchingSupport(const ON_4dex& A, const ON_4dex& B)
 {
   int nsup  = 0;
@@ -827,7 +827,7 @@ bool GJK_Simplex::Includes(int aind, int bind) // true if (aind, bind) is a vert
   return false;
 }
 
-// To supply an inital seed simplex Adex and Bdex must be valid and 
+// To supply an initial seed simplex Adex and Bdex must be valid and 
 // have matching support specifically
 //     Adex[i]<A.Count() and Bdex[i]<B.Count()   for all i
 //     Adex[i]<0 iff Bdex[i]<0  for all i
@@ -848,7 +848,7 @@ bool ON_ConvexPoly::GetClosestPointSeeded(const ON_ConvexPoly& B,
   ON_3dVector v(0,0,0);
 
 
-  // If Adex and Bdex are valid on entry we use them as an inital 
+  // If Adex and Bdex are valid on entry we use them as an initial 
   // seed for the trial simplex.  This case is indicated by setting
   // bFirstPass 
   bool bFirstPass = false;       
@@ -927,7 +927,7 @@ bool ON_ConvexPoly::GetClosestPointSeeded(const ON_ConvexPoly& B,
 				if (!bFirstPass)
 					GJK.AddVertex(W, wA, wB);
 
-        // The key to the implemetation of this algorithm is contained in Simplex::GetClosestPointToOrigin()
+        // The key to the implementation of this algorithm is contained in Simplex::GetClosestPointToOrigin()
 				if (GJK.Simp.GetClosestPointToOrigin(GJK.Bary))
 				{
 					bFirstPass = false;
@@ -944,7 +944,7 @@ bool ON_ConvexPoly::GetClosestPointSeeded(const ON_ConvexPoly& B,
           }
           else
           {
-            /* this is error recovery code. it is currenly DISABLED
+            /* this is error recovery code. it is currently DISABLED
             // The last step resulted in crap lets undo it and set done
             int n = GJK.Simp.Count() - 1;
             GJK.RemoveVertex(n);
@@ -957,7 +957,7 @@ bool ON_ConvexPoly::GetClosestPointSeeded(const ON_ConvexPoly& B,
 				}
 				else
 				{
-					// In this case I am going to terminte the iteration.  If this was a FirstPass with user supplied initial guess
+					// In this case I am going to terminate the iteration.  If this was a FirstPass with user supplied initial guess
 					// then we restart the algorithm without the initial guess.
 					break;
 				}

--- a/opennurbs_convex_poly.h
+++ b/opennurbs_convex_poly.h
@@ -32,8 +32,8 @@ public:
   ON_3dSimplex& operator=(const ON_3dSimplex& rhs) = default;
   ~ON_3dSimplex() = default;
 
-  int Count() const;				// Number of Verticies <=4
-  bool IsValid(double eps) const;			// true if the Verticies are affinely independent
+  int Count() const;				// Number of Vertices <=4
+  bool IsValid(double eps) const;			// true if the Vertices are affinely independent
 
   /* 
   Description:
@@ -51,7 +51,7 @@ public:
   /*
   Description:
     Find Closest Point to this simplex from a base point P0 or the Origin.
-    If true is retuned then Evaluate(Bary) is the closest point on the Simplex.
+    If true is returned then Evaluate(Bary) is the closest point on the Simplex.
   maximum_distance - optional upperbound on closest point.  If maximum_distance>=0 is specified and
             Dist(P0, Simplex)>maximum_distance then false is returned.
   */
@@ -186,7 +186,7 @@ private:
 
 /*
 This is a base class for a convex polytope in 3d space, i.e. the convex hull of a
-finite set of points called verticies.
+finite set of points called vertices.
 
 This is the base type in the implementation of the GJK algorithm
 ClosestPoint(ON_ConvexPoly& A, ON_ConvexPoly& B, ...)
@@ -196,7 +196,7 @@ class ON_CLASS ON_ConvexPoly
 {
 public:
   /*
-  Returns: Number of verticies >=0
+  Returns: Number of vertices >=0
   */
   virtual int Count() const = 0;
    /* 
@@ -220,7 +220,7 @@ public:
 
   /*
   Description:
-  For any vector W there is a vetex that is Support(W)
+  For any vector W there is a vertex that is Support(W)
   SupportIndex( W, i0) returns a vertex index for a vertex that is the support.
   Veretx( K.SupportIndex( W ))  = K.Support(W );
   */
@@ -229,9 +229,9 @@ public:
  /*
  Description:
    Points in a Convex Polytope are parameterized , not necessaily uniquely,
-   by an ON_4dex of vertex indicies and a 4d barycentric point B
+   by an ON_4dex of vertex indices and a 4d barycentric point B
     Evaluate(Ind, B ) = Sum_{i=0,..,3} Vertex(Ind[i])*B[i], where the sum is taken over i such that Ind[i]>=0
-   If B is a barycentric coordinte
+   If B is a barycentric coordinate
   		 B[i]>=0 and B[0] + B[1] + B[2] + B[3] = 1.0
    then Evaluate( Ind, B) is a point in the convex polytope
   */
@@ -304,7 +304,7 @@ Details:
 
   /*
   Description:
-    This is a bound on the collection of verticies.
+    This is a bound on the collection of vertices.
     Vertex(i).MaximumCoordinate()<= MaximumCoordinate() for all i
   */
   virtual double MaximumCoordinate() const = 0;
@@ -313,8 +313,8 @@ Details:
   Description:
     A point represented by a ON_4dex D and a barycentric coordinate B
     can be put in a standard form so that non-negative elements of D are unique and
-    corresponding coordinates are positive.  Furthemore, the non-negative
-    indicies are all listed before the unset ( neagative ) values
+    corresponding coordinates are positive.  Furthermore, the non-negative
+    indices are all listed before the unset ( neagative ) values
   */
   static bool  Standardize(ON_4dex& D, ON_4dPoint& B);
 
@@ -334,8 +334,8 @@ Details:
   virtual ~ON_ConvexPoly() {};
 };
 
-// 3d convex hull defined by an explicit collection of points called verticies.
-// Note: verticies need not be extreme points
+// 3d convex hull defined by an explicit collection of points called vertices.
+// Note: vertices need not be extreme points
 
 // WARNING:  Points are referenced not stored for optimal performance in'
 //           some applications.
@@ -371,8 +371,8 @@ private:
   int m_stride=3;
 };
 
-// 3d convex hull defined by an explicit collection of points called verticies.
-// Note: verticies need not be extreme points     
+// 3d convex hull defined by an explicit collection of points called vertices.
+// Note: vertices need not be extreme points     
 class ON_CLASS ON_ConvexHullPoint2 : public ON_ConvexPoly
 {
 public:
@@ -391,7 +391,7 @@ public:
 
   virtual ~ON_ConvexHullPoint2() override {};
 
-  int AppendVertex(const ON_3dPoint& P); // return index of new vertex.  must set Adjacent Indicies.
+  int AppendVertex(const ON_3dPoint& P); // return index of new vertex.  must set Adjacent Indices.
 	void Empty();
 
   bool SetCapacity(int vcnt) {
@@ -410,8 +410,8 @@ private:
 	Compute Convex hull of 2d points
 	Parameters:
 	 Pnt - array of points,  this is array of working data.  The points are sorted in place as part of the algorithm
-	 HUll - the sequence Hull[0], HUll[1]...  ,*Hull.Last() == Hull[0] defines the convex hull with a positive orientation retuns 2.
-	 PntInd - otional array to be filled in so that Hull[i] = Pnt[ PntInd[i]] where Pnt is the original input point
+	 HUll - the sequence Hull[0], HUll[1]...  ,*Hull.Last() == Hull[0] defines the convex hull with a positive orientation returns 2.
+	 PntInd - optional array to be filled in so that Hull[i] = Pnt[ PntInd[i]] where Pnt is the original input point
 	Returns
 	 dimension of the convex hull
 	 2 - Hull is 2 dimensional

--- a/opennurbs_crc.cpp
+++ b/opennurbs_crc.cpp
@@ -77,7 +77,7 @@ ON__UINT16 ON_CRC16( ON__UINT16 current_remainder, size_t count, const void* p )
 	  // update crc remainder
 
     // Dale Lear September 2020
-    // I was comparing 16-bit crc, 32-bit crc, MAD5 and SHA-1 hash calcualation speeds.
+    // I was comparing 16-bit crc, 32-bit crc, MAD5 and SHA-1 hash calculation speeds.
     // It turns out, that compilers and optimizers have improved a fair bit since 1994 when this code was written.
     // Manual loop unrolling doesn't help (this used to make a measurable difference in 1994 when we used Watcom C on Win 3.1.)
     // The TestHashSpeed command tests hashing speeds. Short story - use either ON_CRC32 or ON_SHA1. 

--- a/opennurbs_crc.h
+++ b/opennurbs_crc.h
@@ -21,7 +21,7 @@ ON_BEGIN_EXTERNC
 
 /*
 Description:
-  Continues 16 bit CRC calulation to include the buffer.
+  Continues 16 bit CRC calculation to include the buffer.
 
 Parameters:
   current_remainder - [in]
@@ -70,7 +70,7 @@ ON__UINT16 ON_CRC16(
 
 /*
 Description:
-  Continues 32 bit CRC calulation to include the buffer
+  Continues 32 bit CRC calculation to include the buffer
 
   ON_CRC32() is a slightly altered version of zlib 1.3.3's crc32()
   and the zlib "legal stuff" is reproduced below.

--- a/opennurbs_curve.cpp
+++ b/opennurbs_curve.cpp
@@ -587,7 +587,7 @@ bool ON_Curve::IsClosed() const
       //        as the one used in ON_PolyCurve::HasGap().
       // June 2019 - sometime in the past decade ON_PolyCurve::HasGap()
       // changed and the test there is different from this test.
-      // The initial "Note" no longer applies becaue it's no longer
+      // The initial "Note" no longer applies because it's no longer
       // clear why the current ON_PolyCurve::HasGap() was changed.
       if ( ON_PointsAreCoincident( dim, false, a, p ) ) 
       {
@@ -678,7 +678,7 @@ bool ON_Curve::GetNextDiscontinuity(
     {
       // 20 March 2003 Dale Lear:
       //   Have to look for locus discontinuities at ends.
-      //   Must test both ends becuase t0 > t1 is valid input.
+      //   Must test both ends because t0 > t1 is valid input.
       //   In particular, for ON_CurveProxy::GetNextDiscontinuity() 
       //   to work correctly on reversed "real" curves, the 
       //   t0 > t1 must work right.
@@ -1009,7 +1009,7 @@ bool ON_Curve::EvTangent(
   {
     if ( Ev2Der( t, point, D1, D2, side, hint ) )
     {
-      // Use l'Hopital's rule to show that if the unit tanget
+      // Use l'Hopital's rule to show that if the unit tangent
       // exists, the 1rst derivative is zero, and the 2nd
       // derivative is nonzero, then the unit tangent is equal
       // to +/-the unitized 2nd derivative.  The sign is equal
@@ -1880,7 +1880,7 @@ bool ON_NurbsCurve::RepairBadKnots( double knot_tolerance, bool bRepair )
           {
             // 15-June-2020 
             // Remove degenerate and small spans at the end, with out changing the domain 
-            // and trying to maintain parametric curve ( i.e, C: Domain->R^d is invarient).
+            // and trying to maintain parametric curve ( i.e, C: Domain->R^d is invariant).
             DestroyRuntimeCache();
   
             if (knot_tolerance > 0)
@@ -1915,7 +1915,7 @@ bool ON_NurbsCurve::RepairBadKnots( double knot_tolerance, bool bRepair )
           {
             // 15-June-2020 
              // Remove degenerate and small spans at the end, with out changing the domain 
-             // and trying to maintain parametric curve ( i.e, C: Domain->R^d is invarient). 
+             // and trying to maintain parametric curve ( i.e, C: Domain->R^d is invariant). 
             DestroyRuntimeCache();
             if (knot_tolerance > 0)
             {
@@ -2947,7 +2947,7 @@ static void SortCurveEndData(int count, ON_SimpleArray<CurveJoinEndData>& EData,
                              ON_SimpleArray<int>& Singles)
 
 {
-  //sort possiblities by distance
+  //sort possibilities by distance
   JoinEndCompareContext context;
   context.bUseTan = bUseTanAngle;
   context.dot_tol = dot_tol;

--- a/opennurbs_curve.h
+++ b/opennurbs_curve.h
@@ -376,7 +376,7 @@ public:
       at the start of the G2 curve segment that was
       tested.
   Returns:
-    True if the paramter t is on a arc segment of the curve.
+    True if the parameter t is on a arc segment of the curve.
   */
   bool IsArcAt( 
     double t, 
@@ -470,7 +470,7 @@ public:
               possible to repeatedly call GetNextDiscontinuity
               and step through the discontinuities.
     t1 - [in] (t0 != t1)  If there is a discontinuity at t1 is 
-              will be ingored unless c is a locus discontinuity
+              will be ignored unless c is a locus discontinuity
               type and t1 is at the start or end of the curve.
     t - [out] if a discontinuity is found, then *t reports the
           parameter at the discontinuity.
@@ -481,7 +481,7 @@ public:
         discontinuity found at *t.  A value of 1 means the first 
         derivative or unit tangent was discontinuous.  A value 
         of 2 means the second derivative or curvature was 
-        discontinuous.  A value of 0 means teh curve is not
+        discontinuous.  A value of 0 means the curve is not
         closed, a locus discontinuity test was applied, and
         t1 is at the start of end of the curve.
         If 'c', the type of continuity to test for 
@@ -576,7 +576,7 @@ public:
   // Returns:
   //   true if curve was reversed.
   // Remarks:
-  //   If reveresed, the domain changes from [a,b] to [-b,-a]
+  //   If reversed, the domain changes from [a,b] to [-b,-a]
   virtual 
   bool Reverse()=0;
 
@@ -860,8 +860,8 @@ public:
     v_stride - [in] (>=Dimension()) stride to use for the v[] array
     v - [out] array of length (der_count+1)*v_stride
         curve(t) is returned in (v[0],...,v[m_dim-1]),
-        curve'(t) is retuned in (v[v_stride],...,v[v_stride+m_dim-1]),
-        curve"(t) is retuned in (v[2*v_stride],...,v[2*v_stride+m_dim-1]),
+        curve'(t) is returned in (v[v_stride],...,v[v_stride+m_dim-1]),
+        curve"(t) is returned in (v[2*v_stride],...,v[2*v_stride+m_dim-1]),
         etc.
     side - [in] optional - determines which side to evaluate from
                 =0   default
@@ -1116,7 +1116,7 @@ public:
 
   // Description:
   //   Destroys the runtime curve tree used to speed closest
-  //   point and intersection calcuations.
+  //   point and intersection calculations.
   // Remarks:
   //   If the geometry of the curve is modified in any way,
   //   then call DestroyCurveTree();  The curve tree is 
@@ -1424,9 +1424,9 @@ bool ON_SortCurves(
 
 /*
 Description:
-  Determine the orientaion (counterclockwise or clockwise) of a closed
+  Determine the orientation (counterclockwise or clockwise) of a closed
   planar curve.
-Paramters:
+Parameters:
   curve - [in] simple (no self intersections) closed planar curve
   xform - [in] Transformation to map the curve to the xy plane. If the
                curve is parallel to the xy plane, you may pass nullptr.
@@ -1445,11 +1445,11 @@ int ON_ClosedCurveOrientation(const ON_Curve& curve, const ON_Plane& plane);
 
 /*
 Description:
-  Get a crude aproximation of the signed area of the region in the 
+  Get a crude approximation of the signed area of the region in the 
   x-y plane traced out by the curve.  This is useful for calculating
   the orientation of projections of loops to planes when you have
   more than one curve.
-Paramters:
+Parameters:
   curve - [in] 
   domain - [in]
     optional sub-domain. (null if entire curve should be used).

--- a/opennurbs_cylinder.h
+++ b/opennurbs_cylinder.h
@@ -30,11 +30,11 @@ class ON_CLASS ON_Cylinder
 public:
   ON_Cylinder(); // zeros all fields - cylinder is invalid
 
-  ON_Cylinder( // infinte cylinder
+  ON_Cylinder( // infinite cylinder
     const ON_Circle&  // point on the bottom plane
     );
 
-  ON_Cylinder( // infinte cylinder
+  ON_Cylinder( // infinite cylinder
     const ON_Circle&,  // point on the bottom plane
     double             // height
     );

--- a/opennurbs_date.cpp
+++ b/opennurbs_date.cpp
@@ -35,12 +35,12 @@ bool ON_IsGregorianLeapYear(
   // the Gregorian calendar was introduced 24, February 1582, in 
   // the Papal States, Spain, Portugal, the Polish-Lithuanian
   // Commonwealth, and most of Italy.  However the Julian leap
-  // day was omitted for the first 10 occurances to correct
+  // day was omitted for the first 10 occurrences to correct
   // for the "vernal equinox drift" the Julian calendar had
   // introduced from  AD 325 to 1582.  The goal was to have
   // March 21 be the date of the vernal equinox.
   // As a result, the first Gregorian calendary leap day
-  // leap day in the Gregorian calendar occured on Feb 29, 1624.
+  // leap day in the Gregorian calendar occurred on Feb 29, 1624.
   return ( year >= 1624 && 0 == (year %4) && (0 == (year%400) || 0 != (year%100)) );
 }
 

--- a/opennurbs_defines.h
+++ b/opennurbs_defines.h
@@ -247,14 +247,14 @@ double ON_RadiansFromDegrees(
 // The reasons ON_UNSET_VALUE is a valid finite number are:
 //
 //   1) It needs to round trip through fprintf/sscanf.
-//   2) It needs to persist unchanged through assigment
+//   2) It needs to persist unchanged through assignment
 /       and not generate exceptions when assigned.
 //   3) ON_UNSET_VALUE == ON_UNSET_VALUE needs to be true.
 //   4) ON_UNSET_VALUE != ON_UNSET_VALUE needs to be false.
 //
 // Ideally, it would also have these SNaN attributes
 //   * When used in a calculation, a floating point exception
-//     occures.
+//     occurs.
 //   * No possibility of a valid calculation would generate
 //     ON_UNSET_VALUE.
 //   * float f = (float)ON_UNSET_VALUE would create an invalid
@@ -273,7 +273,7 @@ double ON_RadiansFromDegrees(
 #define ON_UNSET_POSITIVE_FLOAT 1.234321e+38f
 #define ON_UNSET_FLOAT -ON_UNSET_POSITIVE_FLOAT
 
-// When unsinged int values are used in a context where 
+// When unsigned int values are used in a context where 
 // 0 is a valid index and there needs to be a value that 
 // indicates the index is not set, use ON_UNSET_UINT_INDEX.
 #define ON_UNSET_UINT_INDEX 0xFFFFFFFFU
@@ -312,12 +312,12 @@ The values must never be a valid user heap or stack pointer value.
 
 /*
 Description:
-Paramters:
+Parameters:
   x - [out] returned value of x is an SNan
             (signalling not a number).
 Remarks:
   Any time an SNaN passes through an Intel FPU, the result
-  is a QNaN (quiet nan) and the invalid operation excpetion
+  is a QNaN (quiet nan) and the invalid operation exception
   flag is set.  If this exception is not masked, then the
   exception handler is invoked.
  
@@ -904,11 +904,11 @@ public:
 
   /*
   Returns:
-    Empty string or the git hash of the revison of the source code used to build this application.
+    Empty string or the git hash of the revision of the source code used to build this application.
     The git hash is a hexadecimal number represented in UTF-8 string.
   Remarks:
     Developer builds return "".
-    Build system builds return the git revsion hash.
+    Build system builds return the git revision hash.
   */
   static const char* SourceGitRevisionHash();
 
@@ -1124,7 +1124,7 @@ public:
     /// ON::LengthUnitSystem::None indicates no length unit system. The scale factor
     /// when converting between a specified unit system and None is always 1.0.
     /// ON::LengthUnitSystem::None is used as a unit system for models and
-    /// instance defitions that should be imported or referenced with no
+    /// instance definitions that should be imported or referenced with no
     /// scaling applied.
     ///</summary>
     None =  0, 
@@ -1280,7 +1280,7 @@ public:
 
     ///<summary>
     /// The ON::LengthUnitSystem::Unset is used to indicate no unit system is set.
-    /// This is a differnt condition from ON::LengthUnitSystem::None. 
+    /// This is a different condition from ON::LengthUnitSystem::None. 
     ///</summary>
     Unset = 255
   };
@@ -1559,7 +1559,7 @@ public:
     Unset = 0,
     
     ///<summary>
-    /// Interactivly ask the user to choose one of the following methods
+    /// Interactively ask the user to choose one of the following methods
     /// to resolve component name conflicts.
     ///</summary>
     QueryMethod = 1,
@@ -1587,7 +1587,7 @@ public:
 
     ///<summary>
     /// Keep both components.
-    /// Resolve the name conflict by interactivly asking for an unused name 
+    /// Resolve the name conflict by interactively asking for an unused name 
     /// to assign to the new component.
     ///</summary>
     KeepBothComponentsQueryRename = 5,
@@ -1786,7 +1786,7 @@ public:
 
   // The x/y/z_2pt_perspective_view projections are ordinary perspective
   // projection. Using these values insures the ON_Viewport member 
-  // fuctions properly constrain the camera up and camera direction vectors
+  // functions properly constrain the camera up and camera direction vectors
   // to preserve the specified perspective vantage.
   enum view_projection : unsigned int
   { 
@@ -2170,7 +2170,7 @@ public:
 
   //// surface_loft_end_condition //////////////////////////////////////////////
   //
-  // End condition paramter values for  ON_Curve::CreateCubicLoft() and
+  // End condition parameter values for  ON_Curve::CreateCubicLoft() and
   // ON_Surface::CreateCubicLoft().
   enum cubic_loft_end_condition
   {
@@ -2219,7 +2219,7 @@ public:
     Aligned = 1,
 
     ///<summary>
-    /// Angle bewteen two lines.
+    /// Angle between two lines.
     ///</summary>
     Angular = 2,
 
@@ -2407,7 +2407,7 @@ class ON_CLASS ON_COMPONENT_INDEX
 public:
 
   // Do not change these values; they are stored in 3dm archives
-  // and provide a persistent way to indentify components of
+  // and provide a persistent way to identify components of
   // complex objects.
   enum TYPE
   {

--- a/opennurbs_dimension.cpp
+++ b/opennurbs_dimension.cpp
@@ -835,7 +835,7 @@ bool ON_DimLinear::GetTextXform(
   if (total_arrow_width + total_text_width > dist)     // arrows + text dont fit
   {
     // Try to leave text inside and move arrows outside
-    if (total_text_width > dist)   // text doesnt fit
+    if (total_text_width > dist)   // text doesn't fit
     {
       // move text outside
       text_outside = true;
@@ -2979,7 +2979,7 @@ bool ON_DimAngular::GetTextXform(
 
   if (total_arrow_width + total_text_width > dist)     // arrows + text dont fit
   {
-    if (total_text_width > dist)   // text doesnt fit
+    if (total_text_width > dist)   // text doesn't fit
     {
       // move text outside
       text_outside = true;

--- a/opennurbs_dimension.h
+++ b/opennurbs_dimension.h
@@ -585,12 +585,12 @@ public:
       Pass nullptr if a dim_style is not available.
     line1 - [in]
     point_on_line1 - [in]
-      If point_on_line1 is specified, it inidicates which semi-infinite portion of line1 to dimension.
+      If point_on_line1 is specified, it indicates which semi-infinite portion of line1 to dimension.
       Otherwise the midpoint of lne1 as a segment is used.
       When in doubt, pass ON_3dPoint::UnsetPoint.
     line2 - [in]
     point_on_line2 - [in]
-      If point_on_line2 is specified, it inidicates which semi-infinite portion of line2 to dimension.
+      If point_on_line2 is specified, it indicates which semi-infinite portion of line2 to dimension.
       Otherwise the midpoint of line2 as a segment is used.
       When in doubt, pass ON_3dPoint::UnsetPoint.
     point_on_angular_dimension_arc - [in]

--- a/opennurbs_dimensionstyle.cpp
+++ b/opennurbs_dimensionstyle.cpp
@@ -2279,8 +2279,8 @@ bool ON_DimStyle::Write(
     else
     {
       // ON_ModelComponent::Type::TextStyle, Index() are not  mistakes.
-      // The code in Write3dmReferencedComponentIndex() will convert the dim style index to an approprate
-      // value tht depends on the version ofr 3dm archive (<= V5 or >= V6) being saved.
+      // The code in Write3dmReferencedComponentIndex() will convert the dim style index to an appropriate
+      // value that depends on the version ofr 3dm archive (<= V5 or >= V6) being saved.
       if (!file.Write3dmReferencedComponentIndex(ON_ModelComponent::Type::TextStyle, Index())) break;
     }
 
@@ -3804,7 +3804,7 @@ double ON_DimStyle::TextAdvanceOfCodePoint(unsigned unicode_code_point) const
 
 double ON_DimStyle::TextWidthOfEmSpace() const
 {
-  // This is the fundemental WidthOfXSpace() function. 
+  // This is the fundamental WidthOfXSpace() function. 
   // Other WidthOfXSpace() functions call TextWidthOfEmSpace() when TextAdvanceOfCodePoint(obvious code point) fails.
   // This function may only call TextAdvanceOfCodePoint() and TextHeight().
   double w = TextAdvanceOfCodePoint(ON_UnicodeCodePoint::ON_EmSpace);
@@ -4550,7 +4550,7 @@ void ON_DimStyle::SetLeaderContentAngleRadians(double angle_radians)
     return;
   }
   
-  // positive value so commpare function will work as expected.
+  // positive value so compare function will work as expected.
   while (angle_radians < 0.0)
     angle_radians += 2.0*ON_PI;
   while (angle_radians >= 2.0*ON_PI)
@@ -4686,9 +4686,9 @@ ON::LengthUnitSystem ON_DimStyle::UnitSystem() const
   /// text created in page space will be 3.5 millimeters high.
   /// 
   /// Ideally, ON_DimStyle::UnitSystem() would specify the text height units 
-  /// and ON_DimStyle::DimScale() cound be adjusted as model space extents require.
+  /// and ON_DimStyle::DimScale() could be adjusted as model space extents require.
   /// Text in instance definitions would have a well defined height and references
-  /// to those instance defintions would display predictably in both model space and page space.
+  /// to those instance definitions would display predictably in both model space and page space.
 
   // It is critical that this function never return Unset or CustomUnits.
   // returning None insures unknown scal values are 1 instead of ON_DBL_QNAN
@@ -4715,9 +4715,9 @@ void ON_DimStyle::SetUnitSystem(ON::LengthUnitSystem us)
   /// text created in page space will be 3.5 millimeters high.
   /// 
   /// Ideally, ON_DimStyle::UnitSystem() would specify the text height units 
-  /// and ON_DimStyle::DimScale() cound be adjusted as model space extents require.
+  /// and ON_DimStyle::DimScale() could be adjusted as model space extents require.
   /// Text in instance definitions would have a well defined height and references
-  /// to those instance defintions would display predictably in both model space and page space.
+  /// to those instance definitions would display predictably in both model space and page space.
   if (ON::LengthUnitSystem::CustomUnits == us || ON::LengthUnitSystem::Unset == us)
   {
     ON_ERROR("Annotation styles cannot have unset or custom length units.");
@@ -4754,9 +4754,9 @@ void ON_DimStyle::SetUnitSystemFromContext(
   /// text created in page space will be 3.5 millimeters high.
   /// 
   /// Ideally, ON_DimStyle::UnitSystem() would specify the text height units 
-  /// and ON_DimStyle::DimScale() cound be adjusted as model space extents require.
+  /// and ON_DimStyle::DimScale() could be adjusted as model space extents require.
   /// Text in instance definitions would have a well defined height and references
-  /// to those instance defintions would display predictably in both model space and page space.
+  /// to those instance definitions would display predictably in both model space and page space.
 
 
   ON::LengthUnitSystem dim_style_units = ON::LengthUnitSystemFromUnsigned(static_cast<unsigned int>(UnitSystem()));
@@ -5730,7 +5730,7 @@ void ON_DimStyle::OverrideFields(const ON_DimStyle& source, const ON_DimStyle& p
       break;
     case ON_DimStyle::field::TextMask:
       // SPECIAL CASE
-      // The TextMask values are all modifed individually by the cases for
+      // The TextMask values are all modified individually by the cases for
       // ON_DimStyle::field::DrawMask:
       // ON_DimStyle::field::MaskColorSource:
       // ON_DimStyle::field::MaskColor:

--- a/opennurbs_dimensionstyle.h
+++ b/opennurbs_dimensionstyle.h
@@ -229,7 +229,7 @@ private:
   double                 m_mask_border = 0.0;
 
   // At some point, the reserved fields may have the name changed and be
-  // used to store additional informtion of how to draw the mask,
+  // used to store additional information of how to draw the mask,
   // (feathered edges, rounded corners, etc.).
   unsigned int m_reserved3 = 0;
   mutable ON_SHA1_Hash m_content_hash = ON_SHA1_Hash::ZeroDigest;
@@ -408,7 +408,7 @@ public:
   Returns:
     True:
       "this" and src have identical names, dimension style appearance attributes,
-      and identical atttributes inherited from the same parent dimension style.
+      and identical attributes inherited from the same parent dimension style.
     ON_ModelComponent settings other than Name() and ParentId() are
     not compared.
   Remaraks:
@@ -687,7 +687,7 @@ public:
 
     /// <summary>
     /// AlternateLengthFactor is a rarely used. See Length factor for
-    /// a discription of this property.
+    /// a description of this property.
     ///</summary>
     AlternateLengthFactor          = 18,
 
@@ -1418,7 +1418,7 @@ public:
     using the current settings for TextHeight() and Font().
   Remarks:
     Typically close to the average with of a decimal digit (0123456789) and used
-    to line up colmns of numeric values.
+    to line up columns of numeric values.
   */
   double TextWidthOfFigureSpace() const;
 
@@ -1482,13 +1482,13 @@ public:
   // Distance scale factor for alternate display
   /// <summary>
   /// AlternateLengthFactor is a rarely used. See Length factor for
-  /// a discription of this property.
+  /// a description of this property.
   ///</summary>
   double AlternateLengthFactor() const;
 
   /// <summary>
   /// AlternateLengthFactor is a rarely used. See Length factor for
-  /// a discription of this property.
+  /// a description of this property.
   ///</summary>
   void SetAlternateLengthFactor(double);
 
@@ -1649,7 +1649,7 @@ public:
   Parameters:
     parent_dim_style - [in]
       If you are getting ready to modify and existing annotation object,
-      a good options for this paramter is the dimstyle returned by ON_Annotation.DimStyle();
+      a good options for this parameter is the dimstyle returned by ON_Annotation.DimStyle();
       If you are getting ready to create a new annotation object, then get
       an ON_DimStyleContext class and pass ON_DimStyleContext.CurrentDimStyle().
       In Rhino, use CRhinoDoc.DimStyleContext() to get an ON_DimStyleContext.
@@ -1774,7 +1774,7 @@ public:
   Description:
     For every dimension style property identified by a field_id ON_DimStyle::field enum,
     except Name and Index, if source and parent have different values, then
-    set the field overide for that property to true.
+    set the field override for that property to true.
   Parameters:
     src - [in]
       It is permitted for src to be this.
@@ -1787,7 +1787,7 @@ public:
     );
 
   /*
-  Descripton:
+  Description:
     Set the parent dimension style id to parent.Id() and copies
     all inherited appearance properties from parent.
   Parameters:
@@ -2049,9 +2049,9 @@ public:
   /// text created in page space will be 3.5 millimeters high.
   /// 
   /// Ideally, ON_DimStyle::UnitSystem() would specify the text height units 
-  /// and ON_DimStyle::DimScale() cound be adjusted as model space extents require.
+  /// and ON_DimStyle::DimScale() could be adjusted as model space extents require.
   /// Text in instance definitions would have a well defined height and references
-  /// to those instance defintions would display predictably in both model space and page space.
+  /// to those instance definitions would display predictably in both model space and page space.
   ///</summary>
   ON::LengthUnitSystem UnitSystem() const;
 
@@ -2071,9 +2071,9 @@ public:
   /// text created in page space will be 3.5 millimeters high.
   /// 
   /// Ideally, ON_DimStyle::UnitSystem() would specify the text height units 
-  /// and ON_DimStyle::DimScale() cound be adjusted as model space extents require.
+  /// and ON_DimStyle::DimScale() could be adjusted as model space extents require.
   /// Text in instance definitions would have a well defined height and references
-  /// to those instance defintions would display predictably in both model space and page space.
+  /// to those instance definitions would display predictably in both model space and page space.
   ///</summary>
   void SetUnitSystem(ON::LengthUnitSystem us);
 
@@ -2086,9 +2086,9 @@ public:
     Less ideally, both source_unit_system and destination_unit_system are model space units.
   Parameters:
     bUseName - [in]
-      Consider the name when assinging a unit system.
+      Consider the name when assigning a unit system.
       For example, a dimension style name "Millimters Small" would 
-      be assinged a unit system of millimeters.
+      be assigned a unit system of millimeters.
     source_unit_system - [in]
       unit system in the context where the dimension style originated.
     destination_unit_system - [in]
@@ -2116,9 +2116,9 @@ public:
   /// text created in page space will be 3.5 millimeters high.
   ///
   /// Ideally, ON_DimStyle::UnitSystem() would specify the text height units
-  /// and ON_DimStyle::DimScale() cound be adjusted as model space extents require.
+  /// and ON_DimStyle::DimScale() could be adjusted as model space extents require.
   /// Text in instance definitions would have a well defined height and references
-  /// to those instance defintions would display predictably in both model space and page space.
+  /// to those instance definitions would display predictably in both model space and page space.
   Returns:
     true if the unit system is set to an explicit valid length unit.
   */
@@ -2220,13 +2220,13 @@ private:
   /// <summary>
   /// The LengthResolution property controls the precision of dimension length display.
   ///
-  /// DECIMAL LENGHT DISPLAY: 
+  /// DECIMAL LENGTH DISPLAY: 
   ///   If m_dimension_length_display is any of the ON_DimStyle::LengthDisplay decimal formats,
   ///   then m_lengthresolution is the number of digits after the decimal point.
   ///   For example, if m_lengthresolution is 2, then dimension length display will be n.ff
   ///   If m_lengthresolution=7,  then dimension length display will be n.fffffff.
   ///
-  /// FRACTONAL LENGHT DISPLAY: 
+  /// FRACTONAL LENGTH DISPLAY: 
   ///   If m_dimension_length_display is ON_DimStyle::LengthDisplay::InchesFractional or
   ///   ON_DimStyle::LengthDisplay::FeetAndInches, then fractional length display is used.
   ///   In this case any fractional part will be rouded to the closest multiple 
@@ -2234,7 +2234,7 @@ private:
   ///   Examples: If fractional length display is used and m_lengthresolution=2, 
   //    then the possible fractions are 1/4, 1/2(=2/4), 3/4. 
   ///   If fractional length display is used and m_lengthresolution=7, 
-  //    then any fractional part is rounded to the closest multipl of 1/128 (128=2^7).
+  //    then any fractional part is rounded to the closest multiple of 1/128 (128=2^7).
   /// </summary>
   int m_lengthresolution = 2;
 
@@ -2467,9 +2467,9 @@ private:
   /// text created in page space will be 3.5 millimeters high.
   /// 
   /// Ideally, ON_DimStyle::UnitSystem() would specify the text height units 
-  /// and ON_DimStyle::DimScale() cound be adjusted as model space extents require.
+  /// and ON_DimStyle::DimScale() could be adjusted as model space extents require.
   /// Text in instance definitions would have a well defined height and references
-  /// to those instance defintions would display predictably in both model space and page space.
+  /// to those instance definitions would display predictably in both model space and page space.
   ON::LengthUnitSystem m_dimstyle_unitsystem                    = ON::LengthUnitSystem::None;
 
   ON::TextOrientation m_text_orientation                        = ON::TextOrientation::InPlane;

--- a/opennurbs_ellipse.cpp
+++ b/opennurbs_ellipse.cpp
@@ -326,7 +326,7 @@ bool ON_Ellipse::ClosestPointTo( const ON_3dPoint& point, double* t ) const
               if ( V.Unitize() )
               {
                 // Could not find a seed value for dbrent, 
-                // but V and T are orthoganal, so t0 is 
+                // but V and T are orthogonal, so t0 is 
                 // pretty close.
                 if ( fabs(V*T) <= 0.087155742747658173558064270837474 )
                   return true;

--- a/opennurbs_embedded_file.cpp
+++ b/opennurbs_embedded_file.cpp
@@ -57,7 +57,7 @@ struct ON_BUFFER_SEGMENT
 {
   struct ON_BUFFER_SEGMENT* m_prev_segment;
   struct ON_BUFFER_SEGMENT* m_next_segment;
-  ON__UINT64 m_segment_position0; // postion of first byte in this segment
+  ON__UINT64 m_segment_position0; // position of first byte in this segment
   ON__UINT64 m_segment_position1; // position of the first byte in the next segment
                                   // When a segment is the last one in an ON_Buffer,
                                   // is is common for m_segment_position1 > m_buffer_size.
@@ -542,14 +542,14 @@ ON__UINT32 ON_Buffer::CRC32( ON__UINT32 current_remainder ) const
   for ( seg = m_first_segment; 0 != seg; seg = seg->m_next_segment )
   {
     // prev_seg is set this way so that the error handling
-    // code can use continue statments for non-fatal errors.
+    // code can use continue statements for non-fatal errors.
     prev_seg = seg0;
     seg0 = seg;
 
     if ( seg->m_segment_position0 > seg->m_segment_position1 )
     {
       // This is really bad!  If you can determine how the corruption occurs,
-      // plase make a bug report and tell Dale Lear as soon as possible.
+      // please make a bug report and tell Dale Lear as soon as possible.
       ON_ERROR("corrupt buffer - segment's position values are invalid.");
       continue;
     }
@@ -561,7 +561,7 @@ ON__UINT32 ON_Buffer::CRC32( ON__UINT32 current_remainder ) const
         // The first segment should have seg->m_segment_position0 = 0.
         // We'll keep going after the call to ON_ERROR.
         //
-        // If you can determine how the corruption occured, please
+        // If you can determine how the corruption occurred, please
         // make a bug report and assign it to Dale Lear.
         ON_ERROR("corrupt buffer - first segment has non-zero value for position0.");
       }
@@ -572,7 +572,7 @@ ON__UINT32 ON_Buffer::CRC32( ON__UINT32 current_remainder ) const
       // seg->m_segment_position0 = previous_segment->m_segment_position1.
       // We'll keep going after the call to ON_ERROR.
       //
-      // If you can determine how the corruption occured, please
+      // If you can determine how the corruption occurred, please
       // make a bug report and assign it to Dale Lear.
       ON_ERROR("corrupt buffer - previous segment's position1 !- segment's position0.");
     }
@@ -581,7 +581,7 @@ ON__UINT32 ON_Buffer::CRC32( ON__UINT32 current_remainder ) const
 
     if ( 0 == seg_size )
     {
-      // If you can determine how the corruption occured, please
+      // If you can determine how the corruption occurred, please
       // make a bug report and assign it to Dale Lear.
       ON_ERROR("corrupt buffer - empty segment buffer.");
       continue;
@@ -591,7 +591,7 @@ ON__UINT32 ON_Buffer::CRC32( ON__UINT32 current_remainder ) const
     {
       if ( seg != m_last_segment || seg->m_next_segment )
       {
-        // If you can determine how the corruption occured, please
+        // If you can determine how the corruption occurred, please
         // make a bug report and assign it to Dale Lear.
         ON_ERROR("corrupt buffer - segments contain more bytes than m_buffer_size.");
       }
@@ -604,7 +604,7 @@ ON__UINT32 ON_Buffer::CRC32( ON__UINT32 current_remainder ) const
     {
       if ( seg != m_last_segment || 0 != seg->m_next_segment || size > m_buffer_size )
       {
-        // If you can determine how the corruption occured, please
+        // If you can determine how the corruption occurred, please
         // make a bug report and assign it to Dale Lear.
         ON_ERROR("corrupt buffer - list of segments is too long.");
       }
@@ -632,7 +632,7 @@ bool ON_Buffer::SetCurrentSegment( bool bWritePending )
   //   In this case, true is returned when m_current_position < m_buffer_size
   //   and false is returned in all other cases.
   //
-  // If seeks have occured since the last read or write, m_current_segment
+  // If seeks have occurred since the last read or write, m_current_segment
   // and m_current_segment_offset may need to be updated.
   //
 
@@ -862,7 +862,7 @@ ON__UINT64 ON_Buffer::Read( ON__UINT64 size, void* buffer )
     {
       if ( m_current_position == m_buffer_size && m_current_segment == m_last_segment )
       {
-        // This is a common situation that occures when the read request is for a 
+        // This is a common situation that occurs when the read request is for a 
         // size larger than the remaining number of bytes in the buffer. For example,
         // when repeatedly reading into a fixed size buffer until reasing the end
         // of the file. This is not an error condition.

--- a/opennurbs_evaluate_nurbs.cpp
+++ b/opennurbs_evaluate_nurbs.cpp
@@ -499,7 +499,7 @@ OUTPUT:
         (n)
      bez  (t) = answer[n]
 COMMENTS:
-  Use de Casteljau's algorithm.  Rational fuctions with removable singularities
+  Use de Casteljau's algorithm.  Rational functions with removable singularities
   (like x^2/x) are efficiently and correctly handled.
 EXAMPLE:
   // ...
@@ -1322,7 +1322,7 @@ bool ON_EvaluateNurbsDeBoor(
  *                    knots[0] = ... = knots[order-2] = t (side > 0)
  *                 or
  *                    knots[order-1] = ... = knots[2*order-2] = t (side < 0).
- *                 See the comments concering +/- 2 values of the "side"
+ *                 See the comments concerning +/- 2 values of the "side"
  *                 argument.  In most cases, you can avoid resetting knots
  *                 by carefully choosing the value of "side" and "mult_k".
  *  TL_EvDeBoor()

--- a/opennurbs_evaluate_nurbs.h
+++ b/opennurbs_evaluate_nurbs.h
@@ -113,7 +113,7 @@ Parameters:
 
 COMMENTS:
   If a degree d NURBS has n control points, then the OpenNURBS knot vector 
-  for the entire NURBS curve has length d+n-1. The knot[] paramter to this
+  for the entire NURBS curve has length d+n-1. The knot[] parameter to this
   function points to the 2*d knots active for the span being evaluated.
   
   Most literature, including DeBoor and The NURBS Book,
@@ -299,7 +299,7 @@ Parameters:
               n = v_stride*( (i+j)*(i+j+1)/2 + j).
 
 Returns:
-  True if succcessful.
+  True if successful.
 See Also:
   ON_NurbsSurface::Evaluate
   ON_EvaluateNurbsSpan
@@ -377,7 +377,7 @@ Parameters:
                n = v_stride*( d*(d+1)*(d+2)/6 + (j+k)*(j+k+1)/2 + k) 
 
 Returns:
-  True if succcessful.
+  True if successful.
 See Also:
   ON_NurbsCage::Evaluate
   ON_EvaluateNurbsSpan

--- a/opennurbs_extensions.cpp
+++ b/opennurbs_extensions.cpp
@@ -2572,19 +2572,19 @@ bool ONX_Model::IncrementalReadModelGeometry(
     if (static_cast<unsigned int>(previous_table) >= static_cast<unsigned int>(ON_3dmArchiveTableType::object_table))
     {
       // Yokel either read or skipped reading the geometry table.
-      ON_ERROR("Too late to read the geoemtry table.");
+      ON_ERROR("Too late to read the geometry table.");
       return false;
     }
 
     if (false == archive.BeginRead3dmObjectTable())
     {
-      ON_ERROR("Geoemtry table cannot be read from archive.");
+      ON_ERROR("Geometry table cannot be read from archive.");
       return false;
     }
     active_table = archive.Active3dmTable();
     if (active_table != ON_3dmArchiveTableType::object_table)
     {
-      ON_ERROR("Catestrophic geoemtry table reading error.");
+      ON_ERROR("Catestrophic geometry table reading error.");
       return false;
     }
   }  
@@ -2598,7 +2598,7 @@ bool ONX_Model::IncrementalReadModelGeometry(
   ON_3dmArchiveTableStatus object_table_status = archive.Archive3dmTableStatus(ON_3dmArchiveTableType::object_table);
   if (ON_3dmArchiveTableType::object_table != object_table_status.m_table_type)
   {
-    ON_ERROR("Catestrophic geoemtry table reading error.");
+    ON_ERROR("Catestrophic geometry table reading error.");
     return false;
   }
 
@@ -2609,12 +2609,12 @@ bool ONX_Model::IncrementalReadModelGeometry(
     break;
   case ON_3dmArchiveTableStatus::TableState::Finished:
     {
-      ON_ERROR("Geoemtry table has already been read from archive.");
+      ON_ERROR("Geometry table has already been read from archive.");
       return false;
     }
   default:
     {
-      ON_ERROR("Geoemtry table reading error.");
+      ON_ERROR("Geometry table reading error.");
       return false;
     }
   }
@@ -4940,7 +4940,7 @@ void ONX_ModelTest::Internal_ReadTest(
 
     //const unsigned int original_model_3dm_file_version = (unsigned int)(model0->m_3dm_file_version);
 
-    // Write original_model to a termporary archive using "buffer" for storage. 
+    // Write original_model to a temporary archive using "buffer" for storage. 
     ON_Buffer temporary_buffer[2];
     const unsigned int temporary_buffer_3dm_version[2] = { current_3dm_file_version - 10, current_3dm_file_version };
 

--- a/opennurbs_extensions.h
+++ b/opennurbs_extensions.h
@@ -55,7 +55,7 @@ public:
 
   /*
   Returns:
-    Number of failures, erros, and warnings.
+    Number of failures, errors, and warnings.
   */
   unsigned int TotalCount() const;
 
@@ -443,11 +443,11 @@ public:
       continuing.  
   Returns:
     True
-      Succesful.  If model_geometry_reference.IsEmpty() is true, 
+      Successful.  If model_geometry_reference.IsEmpty() is true, 
       then no more geometry objects are available and you should call
       IncrementalReadFinish().
     False
-      An error occured and reading should terminate.
+      An error occurred and reading should terminate.
   Remarks:
     You must call IncrementalReadBegin() before making any calls to
     IncrementalReadModelObject().
@@ -644,7 +644,7 @@ public:
   ON_String m_sStartSectionComments;
 
   // Properties include revision history, notes, information about
-  // the applicaton that created the file, and an optional preview image.
+  // the application that created the file, and an optional preview image.
   ON_3dmProperties m_properties;
 
   // Settings include tolerance, and unit system, and defaults used
@@ -824,7 +824,7 @@ public:
   bManagedComponent  - [in]
     If bManagedComponent is true, then ~ONX_Model will delete the component.
     If bManagedComponent is false, then you are responsible for insuring
-    the component exists past the desctruction of this ONX_Model.
+    the component exists past the destruction of this ONX_Model.
 
   bResolveIdAndNameConflicts  - [in]
     If bResolveIdAndNameConflicts is false, then model_component.Id() must be non-nil 
@@ -921,7 +921,7 @@ public:
 
   /*
   Description:
-    Add geometry and attibutes to this model and control how the instances are managed.
+    Add geometry and attributes to this model and control how the instances are managed.
 
   Parameters:
     bManageGeometry - [in]
@@ -943,7 +943,7 @@ public:
       are active.
 
     attributes - [in]
-      nullptr if not avaiable.
+      nullptr if not available.
   
   bResolveIdAndNameConflicts - [in]
     If bResolveIdAndNameConflicts is false, then attributes must be nullptr 
@@ -1031,7 +1031,7 @@ public:
   Remarks:
     ONX_Model::ComponentFromRuntimeSerialNumber() used to get a reference rather than a copy of the model's 
     primary ON_ModelComponentReference. This is the function that must be used if a caller is going to 
-    use exclusive access funcitons like
+    use exclusive access functions like
 
       ON_ModelComponent* ON_ModelComponentReference::ExclusiveModelComponent()
       ON_3dmObjectAttributes* ON_ModelGeometryComponent::ExclusiveAttributes()
@@ -1740,12 +1740,12 @@ public:
     Fail = 1,
 
     ///<summary>
-    /// Test was performed and completed, but at least one ON_ERROR occured.
+    /// Test was performed and completed, but at least one ON_ERROR occurred.
     ///</summary>
     Errors = 2,
 
     ///<summary>
-    /// Test was performed and completed, but at least one ON_WARNING occured.
+    /// Test was performed and completed, but at least one ON_WARNING occurred.
     ///</summary>
     Warnings = 3,
  
@@ -1756,13 +1756,13 @@ public:
     Pass = 4,
 
     ///<summary>
-    /// Test was not perfomed because the input did not satisfy prerequisites or an
+    /// Test was not performed because the input did not satisfy prerequisites or an
     /// earlier test failed.
     /// For example, if a ONX_ModelReadTest::TestType::ReadWriteReadCompare 
     /// test is requested and the source file is a Rhino 1 file, the compare
     /// test is skipped.
     /// For example, if a ONX_ModelReadTest::TestType::ReadWriteRead 
-    /// test is requested and the Write test failes, the second Read test is skipped.
+    /// test is requested and the Write test fails, the second Read test is skipped.
     ///</summary>
     Skip = 5,
   };
@@ -1805,7 +1805,7 @@ public:
       If text_log is not nullptr, then a summary of the test is sent to text_log.
   Returns:
     True if every test passed with no warnings or errors.
-    False if a test failed or warnings or errors occured.
+    False if a test failed or warnings or errors occurred.
   */
   bool ReadTest(
     const char* file_path,
@@ -1833,7 +1833,7 @@ public:
       If text_log is not nullptr, then a summary of the test is sent to text_log.
   Returns:
     True if every test passed with no warnings or errors.
-    False if a test failed or warnings or errors occured.
+    False if a test failed or warnings or errors occurred.
   */
   bool ReadTest(
     const wchar_t* file_path,
@@ -1861,7 +1861,7 @@ public:
       If text_log is not nullptr, then a summary of the test is sent to text_log.
   Returns:
     True if every test passed with no warnings or errors.
-    False if a test failed or warnings or errors occured.
+    False if a test failed or warnings or errors occurred.
   */
   bool ReadTest(
     FILE* fp,
@@ -1889,7 +1889,7 @@ public:
       If text_log is not nullptr, then a summary of the test is sent to text_log.
   Returns:
     True if every test passed with no warnings or errors.
-    False if a test failed or warnings or errors occured.
+    False if a test failed or warnings or errors occurred.
   */
   bool ReadTest(
     ON_BinaryArchive& archive,

--- a/opennurbs_file_utilities.cpp
+++ b/opennurbs_file_utilities.cpp
@@ -826,7 +826,7 @@ const ON_wString ON_FileSystemPath::CleanPath(
   wchar_t* clean_start = clean_head;
   if (bIsUNCHostName)
   {
-    clean_start += 3; // skip \\ and first charater of host name
+    clean_start += 3; // skip \\ and first character of host name
     
     // skip rest of host name
     while ( IsPermittedInHostName(*clean_start) )
@@ -1393,7 +1393,7 @@ const ON_wString ON_FileSystemPath::RelativePath(
   if (false == IsDirSep(*full_tail) || false == IsDirSep(*base_tail))
   {
     // A double directory separator after the initial CleanAndRemoveFileName()
-    // calls indicates invalid file path informtion.
+    // calls indicates invalid file path information.
     return best_answer;
   }
 
@@ -1407,7 +1407,7 @@ const ON_wString ON_FileSystemPath::RelativePath(
   if (IsDirSep(*full_tail) || IsDirSep(*base_tail))
   {
     // A double directory separator after the initial ON_FileSystemPath::CleanPath()
-    // calls indicates invalid file path informtion.
+    // calls indicates invalid file path information.
     return best_answer;
   }
 
@@ -1486,7 +1486,7 @@ const ON_wString ON_FileSystemPath::RelativePath(
     base_tail++;
   }
 
-  // buid relative path
+  // build relative path
   ON_wString relative_path;
   if (0 == dotdot_count)
   {
@@ -2541,7 +2541,7 @@ bool ON_FileIterator::NextItem()
       0, // null output error status
       (4|8|16), // mask common conversion errors
       0, // error_code_point = null terminator inserted at point of conversion error
-      0  // null ouput end-of-string pointer
+      0  // null output end-of-string pointer
       );
     // TODO
     //   Test m_dirent.d_name to make sure it passes m_ws/utf8_file_name_filter
@@ -2845,7 +2845,7 @@ static ON__UINT64 SecondsSinceJanOne1970( FILETIME ft )
   // and "the internet" sometimes cites that as the reason that date is 
   // the "beginning of time" for Windows' FILETIME values.  This convention
   // would slightly simplify the formulae used to account for leap years, 
-  // so it is plausable this might might even be true.
+  // so it is plausible this might might even be true.
 
   ON__UINT64 ft_since_jan_1_1601 = ft.dwHighDateTime;
   ft_since_jan_1_1601 *= 0xFFFFFFFF;

--- a/opennurbs_file_utilities.h
+++ b/opennurbs_file_utilities.h
@@ -320,7 +320,7 @@ public:
     path - [in]
       path to split
   Returns:
-    The file name extension portion of the path, inlcuding the leading period or "dot".
+    The file name extension portion of the path, including the leading period or "dot".
   */
   static const ON_wString FileNameExtensionFromPath(
     const wchar_t* path
@@ -727,7 +727,7 @@ public:
       FILE pointer returned by ON_FileStream::Open().
   Returns:
     >= 0: current file position
-      -1: an error occured
+      -1: an error occurred
   */
   static ON__INT64 CurrentPosition( FILE* fp );
 
@@ -812,7 +812,7 @@ public:
     fp - [in]
       FILE pointer returned by ON_FileStream::Open().
   Returns:
-    true if flush was successful.  False if an error occured.
+    true if flush was successful.  False if an error occurred.
   */
   static bool Flush( FILE* fp );
 
@@ -834,7 +834,7 @@ public:
       file's contents were last modified is returned here as the number of
       seconds since midnight January 1, 1970.
   Returns:
-    true if the query was successful.  False if an error occured.
+    true if the query was successful.  False if an error occurred.
   */
   static bool GetFileInformation( 
     FILE* fp,
@@ -868,7 +868,7 @@ public:
   ON_ContentHash& operator=(const ON_ContentHash&)  = default;
 
   /*
-  Descripton:
+  Description:
     Create an ON_ContentHash class with the specified size, hash and times.
   Parameters:
     sha1_name_hash - [in]
@@ -886,7 +886,7 @@ public:
       If 0 is passed in, the current time is used.
     content_last_modified_time - [in]
       Pass 0 if not known.
-      The time the hashed information that was last modifed in seconds since January 1, 1970 UCT.
+      The time the hashed information that was last modified in seconds since January 1, 1970 UCT.
       If content_last_modified_time > hash_time, then 0 is used.
   Returns:
     An ON_ContentHash with size and SHA-1 hash and times set from the parameters,
@@ -900,7 +900,7 @@ public:
     );
 
   /*
-  Descripton:
+  Description:
     Create an ON_ContentHash from a memory buffer.
   Parameters:
     sha1_name_hash - [in]
@@ -921,7 +921,7 @@ public:
    );
 
   /*
-  Descripton:
+  Description:
     Create an ON_ContentHash from a file stream.
   Parameters:
     sha1_file_name_hash - [in]
@@ -931,7 +931,7 @@ public:
     fp - [in] pointer to a file opened with ON:FileOpen(...,"rb")
   Returns:
     An ON_ContentHash with size and SHA-1 hash and times set from the file,
-    hash time = now, and content last modifed time set from the file system
+    hash time = now, and content last modified time set from the file system
     information returned by ON_FileStream::GetFileInformation().
   */
   static ON_ContentHash CreateFromFile( 
@@ -940,13 +940,13 @@ public:
     );
 
   /*
-  Descripton:
+  Description:
     Create an ON_ContentHash from a file stream.
   Parameters:
     filename - [in] name of file.
   Returns:
     An ON_ContentHash with size and SHA-1 hash and times set from the file,
-    hash time = now, and content last modifed time set from the file system
+    hash time = now, and content last modified time set from the file system
     information returned by ON_FileStream::GetFileInformation().
   */
   static ON_ContentHash CreateFromFile( 
@@ -977,13 +977,13 @@ public:
 
   /*
   Returns:
-    Time the hash SHA-1 hash was cacluated in seconds since January 1, 1970 UCT.
+    Time the hash SHA-1 hash was calculated in seconds since January 1, 1970 UCT.
   */
   ON__UINT64 HashCalculationTime() const;
 
   /*
   Returns:
-    Time the hashed content was last modifed in seconds since January 1, 1970 UCT.
+    Time the hashed content was last modified in seconds since January 1, 1970 UCT.
     0 is returned if this time is not known.
 
     This time should be used for important decisions as a last resort.
@@ -1028,7 +1028,7 @@ public:
   /*
   Description:
     Test a file to see if it has a matching size and SHA-1 hash.
-  Paramters:
+  Parameters:
     fp - [in] pointer to file opened with ON::OpenFile(...,"rb")
     bSkipTimeCheck - [in] if true, the time of last
        modification is not checked.
@@ -1043,7 +1043,7 @@ public:
   /*
   Description:
     Test a file to see if it has a matching size and SHA-1 content hash.
-  Paramters:
+  Parameters:
     filename - [in]
   Returns:
     True if the file exists, can be read, and has a matching byte_count
@@ -1159,7 +1159,7 @@ public:
 
   /*
   Returns:
-    true if a and b have differnt ByteCount() or SHA-1 content hash values.
+    true if a and b have different ByteCount() or SHA-1 content hash values.
   */
   static bool DifferentContent(
     const ON_ContentHash& a,
@@ -1221,7 +1221,7 @@ private:
   // Time this hash was set (always > 0 if this ON_ContentHash is set).
   ON__UINT64 m_hash_time = 0; // number of seconds since Jan 1, 1970, UCT
 
-  // Time the content was last modifed.
+  // Time the content was last modified.
   // This time is often unknown, or set incorrectly.
   ON__UINT64 m_content_time = 0; // number of seconds since Jan 1, 1970, UCT
 
@@ -1301,10 +1301,10 @@ public:
     ///<summary>File name exists in base path directory.</summary>
     BasePath = 3,
 
-    ///<summary>File with mathing content exists.</summary>
+    ///<summary>File with matching content exists.</summary>
     ContentMatch = 4,
 
-    ///<summary>Most recently modifed file.</summary>
+    ///<summary>Most recently modified file.</summary>
     MostRecent = 5
   };
 #pragma endregion
@@ -1552,7 +1552,7 @@ public:
   Remarks:
     The value of the hash is saved in a runtime cache so
     using this function when comparing paths is efficient
-    when multple compares are required.
+    when multiple compares are required.
   See Also:
     ON_NameHash::CreateFilePathHash( ON_FileReference& file_reference );
   */
@@ -1583,7 +1583,7 @@ private:
 
   mutable ON_ContentHash m_recent_content_hash;
 
-  // m_full_path_hash is chached runtime information. The value is not saved
+  // m_full_path_hash is cached runtime information. The value is not saved
   // in .3dm archives. It is calculated on demand.
   mutable ON_SHA1_Hash m_full_path_hash = ON_SHA1_Hash::EmptyContentHash; // File path hash.
 
@@ -1627,7 +1627,7 @@ public:
     directory_name - [in]
       The directory to look in.
     item_name_filter - [in]
-      If this paramter is null, then the iteration
+      If this parameter is null, then the iteration
       includes all names in the directory.
       The item name to search for. This parameter can 
       include wildcard characters, such as an
@@ -1642,7 +1642,7 @@ public:
       There are no matching items.
 
   Remarks:
-    Calling FirstItem() is eqivalent to calling Initialize() and then calling NextItem().
+    Calling FirstItem() is equivalent to calling Initialize() and then calling NextItem().
   */
   bool Initialize( 
     const wchar_t* directory_name

--- a/opennurbs_font.cpp
+++ b/opennurbs_font.cpp
@@ -688,7 +688,7 @@ ON_ManagedFonts::~ON_ManagedFonts()
     {
       // ON_Font::Default.m_runtime_serial_number = 1 and it is the only instance of a font
       // with m_runtime_serial_number = 1.  
-      // However, the managed_font pointer points to ON_Font::Default, which was destroyed a few miliseconds ago.
+      // However, the managed_font pointer points to ON_Font::Default, which was destroyed a few milliseconds ago.
       // See opennurbs_statics.cpp and observe that construction order is
       // ..., ON_ManagedFonts::List, ON_Font::Unset, ON_Font::Default, ...
       // and destruction order is
@@ -730,7 +730,7 @@ public:
   double m_font_unit_to_normalized_scale = 1.0;
   double m_normalized_to_font_unit_scale = 1.0;
 
-  // Font metrics in the units from the system font defintion.
+  // Font metrics in the units from the system font definition.
   // UPM = font design cell height (often 1000 for PostScript, 2014 for TrueType, ...)
   ON_FontMetrics m_font_unit_metrics;
 
@@ -913,7 +913,7 @@ const ON_Font* ON_ManagedFonts::GetFromFontCharacteristics(
 
   for (;;)
   {
-    // quick test for default font that occurs often enough to warrent the special checking
+    // quick test for default font that occurs often enough to warrant the special checking
     if (bIsUnderlined)
       break;
     if (bIsStrikethrough)
@@ -1137,7 +1137,7 @@ const ON_Font* ON_ManagedFonts::Internal_AddManagedFont(
     // Apple: Helvetic Neue
 
     // managed_font is a missing font.
-    // We have to substitue the correct quartet member (regular/bold/italic/bold-italic).
+    // We have to substitute the correct quartet member (regular/bold/italic/bold-italic).
     // Since managed_font references a font that is not installed on this device,
     // IsItalicInQuartet() and IsBoldInQuartet() will probably fall through to
     // the fallback best guess sections of those functions.
@@ -2793,7 +2793,7 @@ static bool Internal_EqualFamilyName(
 class Internal_FontDelta
 {
   // Internal_FontDelta is a simple minded attempt at measuring the difference between a target font and a candidate font.
-  // It is probably a poor substitued for something fancier like PANOSE information.
+  // It is probably a poor substitute for something fancier like PANOSE information.
   // Unfortunately, we generally do not have PANOSE information about the target font.
 
 public:
@@ -2985,7 +2985,7 @@ public:
     return 0;
   }
 
-  // Points to a cadidate for matching the original font
+  // Points to a candidate for matching the original font
   const ON_Font* m_candidate_font = nullptr;
 
   // 0: exact match
@@ -3425,7 +3425,7 @@ const ON_Font* ON_Font::Internal_DecoratedFont(
   const ON_Font* decorated_font = decorated.ManagedFont();
   if (nullptr != decorated_font && ON_FontFaceQuartet::Member::Unset == decorated_font->m_quartet_member)
   {
-    // Decorated faces are not explicity in quartets,
+    // Decorated faces are not explicitly in quartets,
     // but when dealing with rich text, we need to know what quartet member they are decorating.
     decorated_font->m_quartet_member = this->m_quartet_member;
   }
@@ -4022,7 +4022,7 @@ void ON_FontList::Internal_UpdateSortedLists() const
       {
         const ON_SHA1_Hash sha1 = font->FontCharacteristicsHash();
         if (sha1.IsZeroDigestOrEmptyContentHash())
-          continue; // no valid font wil have either one of these hashes.
+          continue; // no valid font will have either one of these hashes.
       }
       else
       {
@@ -4647,7 +4647,7 @@ const ON_Font* ON_FontList::Internal_FromNames(
 #if defined(ON_RUNTIME_APPLE)
     else
     {
-      // ON Apple platforms, the postscript name is the most reliable indentification
+      // ON Apple platforms, the postscript name is the most reliable identification
       if (false == ON_wString::EqualOrdinal(font->PostScriptName(), postscript_name_match_candidate->PostScriptName(), true))
         font = postscript_name_match_candidate;
     }
@@ -5320,13 +5320,13 @@ const ON_ClassArray< ON_FontFaceQuartet >& ON_FontList::QuartetList() const
       // DirectWrite fonts in opennurbs_win_dwrite.cpp. The Windows LOGFONTs partition
       // families into quartets. These end up with bUsePairCandidate = true.
       // 
-      // 2. In rare cases on Windows, font foundaries or authors fail to specify a LOGFONT name
+      // 2. In rare cases on Windows, font foundries or authors fail to specify a LOGFONT name
       // in the ttc / ttf / postscript / ... file. 
       // If we are able to make a reasonable guess, then we set the member here.
       // 
       // 3. Apple installed fonts are created from CTFont in opennurbs_apple_nsfont.cpp
       // and the LOGFONT information from ttc / ttf / postscript files cannot be retrieved.
-      // There are no Mac OS tools that reliably paritition large font families into
+      // There are no Mac OS tools that reliably partition large font families into
       // quartets.
       // 
       // 4. Missing fonts that are created in ON_Font::FontFromRichTextProperties() have the quartet
@@ -5442,7 +5442,7 @@ const ON_ClassArray< ON_FontFaceQuartet >& ON_FontList::QuartetList() const
 
     if (nullptr == quartet_faces[0][0] && nullptr == quartet_faces[1][0])
     {
-      // This might happen if buggy code encouters a heavy font like Arial Black
+      // This might happen if buggy code encounters a heavy font like Arial Black
       // and incorrectly specifies the heavy regular/italic faces as bold.
       // A quartet name + regular/bold/italic/italic-bold user interface should offer
       // a regular and italic member in this situation.
@@ -5476,7 +5476,7 @@ const ON_ClassArray< ON_FontFaceQuartet >& ON_FontList::QuartetList() const
       }
     }
 
-    // Unset the m_quartet_member on unsed fonts with this quartet name.
+    // Unset the m_quartet_member on unused fonts with this quartet name.
     for (unsigned j = i; j < next_i; ++j)
     {
       f = a[j];
@@ -6015,7 +6015,7 @@ const ON_Font* ON_Font::GetManagedFontFromPostScriptName(
   // This font is not installed.
   ON_Font font(ON_Font::Unset);
 
-  // prefered weight/stretch/style since this font is not installed
+  // preferred weight/stretch/style since this font is not installed
   font.SetFontWeight(ON_Font::Weight::Normal);
   font.SetFontStretch(ON_Font::Stretch::Medium);
   font.SetFontStyle(ON_Font::Style::Upright);
@@ -7120,7 +7120,7 @@ bool ON_Font::SetFontCharacteristics(
     )
   {
     // These two fonts were didstrubuted with ACAD for decades.
-    // Thy have several errors in their defintion including being
+    // Thy have several errors in their definition including being
     // marked as SYMBOL_CHARSET rather than ANSI_CHARSET.
     logfont_charset = ON_Font::WindowsConstants::logfont_symbol_charset;
   }
@@ -7485,7 +7485,7 @@ public:
     if (s2.IsEmpty())
       return ON_SHA1_Hash::EmptyContentHash;
 
-    // add a hypen between family and postscript name
+    // add a hyphen between family and postscript name
     // to insure hash for Family = A and postscript = BC
     // is different from hash for Family = AB and postscript = C
     s1 += ON_wString::HyphenMinus;
@@ -7546,7 +7546,7 @@ const ON_wString ON_Font::FakeWindowsLogfontNameFromFamilyAndPostScriptNames(
   // that use quartets of regular/italic/bold/bold-italic to specify fonts.
   //
   // Because modern fonts can have many faces (Helvetica Neue has 14 as of 2019)
-  // and those faces dont' fit the 1970's LOGFONT model of regular/italic/bold/bold-italic.
+  // and those faces don't fit the 1970's LOGFONT model of regular/italic/bold/bold-italic.
   // American Typewriter and Avenir are other example of commonly used fonts that have 
   // more than 4 faces and don't have fit well into the regular/italic/bold/bold-italic UI.
   //
@@ -7569,7 +7569,7 @@ const ON_wString ON_Font::FakeWindowsLogfontNameFromFamilyAndPostScriptNames(
     // Internal_FakeWindowsLogfontName(family_name,postscript_name,fake_logfont_name,member);
 
     // Cominations that are not explicitly specified are correctly handled by using the family name as the fake logfont name.
-    // The explicity fake logfont name should always be different from the family name.
+    // The explicitly fake logfont name should always be different from the family name.
     Internal_FakeWindowsLogfontName(L"American Typewriter", L"AmericanTypewriter-Light",          L"American Typewriter Light", ON_FontFaceQuartet::Member::Regular),
     Internal_FakeWindowsLogfontName(L"American Typewriter", L"AmericanTypewriter-Semibold",       L"American Typewriter Semibold", ON_FontFaceQuartet::Member::Regular),
     Internal_FakeWindowsLogfontName(L"American Typewriter", L"AmericanTypewriter-CondensedLight", L"American Typewriter Condensed Light", ON_FontFaceQuartet::Member::Regular),
@@ -8099,7 +8099,7 @@ bool ON_Font::IsItalicInQuartet() const
   // NOTE The q.IsEmpty() test above insures at least one of upright2[] or italic2[] has a non nullptr.
 
   if (nullptr == italic2[0] && nullptr == italic2[1])
-    return false; // every font in htis quartet is upright.
+    return false; // every font in this quartet is upright.
 
   if (nullptr == upright2[0] && nullptr == upright2[1])
     return true; // every font in this quartet is italic.
@@ -8194,7 +8194,7 @@ const ON_wString ON_Font::RichTextFontName(
   // IDWriteFont family name, ..., and probably several other choices.
 
   // The complete PostScript name is a bad choice. It doesn't work for
-  // WIndows RTF readers.  Opennurbs relies on a hueristic to convert
+  // WIndows RTF readers.  Opennurbs relies on a heuristic to convert
   // PostScript names to family names.
   //
   // The Windows LOGFONT.lfFaceName is a bad choice. It doesn't work for
@@ -8405,7 +8405,7 @@ static ON_OutlineFigure::Type Internal_FigureTypeFromHashedFontName(
     // NOTE WELL: 
     //  Orach Technic 2L fonts are NOT a double stroke fonts.
     //  The figure outlines are simple closed perimenters
-    //  that contain postive areas. 
+    //  that contain positive areas. 
     //  The behave poorly in simulated bold face.
   };
 
@@ -8808,7 +8808,7 @@ const ON_wString ON_Font::FamilyNameFromDirtyName(
     clean_names.Reserve(16 + installed_count);
     dirty_names.Reserve(16 + 2*installed_count);
 
-    // Append known clean family names that contain a hypen.
+    // Append known clean family names that contain a hyphen.
     clean_names.Append(InternalHashToName(L"AvenirLT-Roman"));
     clean_names.Append(InternalHashToName(L"MecSoft_Font-1"));
     clean_names.Append(InternalHashToName(L"MingLiU_HKSCS-ExtB"));
@@ -8882,7 +8882,7 @@ const ON_wString ON_Font::FamilyNameFromDirtyName(
         //  font and the other_name pointer persist for the lifetime of the application.
         //
         //  Do NOT use the font->Description() string. That string does not persist
-        //  And it adds to additional functionallity because it has the form <clean family name>-...
+        //  And it adds to additional functionality because it has the form <clean family name>-...
         const wchar_t* other_name
           = (0 == j)
           ? static_cast<const wchar_t*>(font->PostScriptName())
@@ -8968,8 +8968,8 @@ const ON_wString ON_Font::FamilyNameFromDirtyName(
   }
 
   // No clean family name is exlicity known for the dirty_name parameter.
-  // Truncate the input dirty_name at the first hypen to remove PostScript face descriptions.
-  // (This is the reason we explicty add all known faces with hypens above).
+  // Truncate the input dirty_name at the first hyphen to remove PostScript face descriptions.
+  // (This is the reason we explicitly add all known faces with hyphens above).
   ON_wString best_guess(dirty_name);
   for (const wchar_t* c = dirty_name; 0 != *c; c++)
   {
@@ -8983,7 +8983,7 @@ const ON_wString ON_Font::FamilyNameFromDirtyName(
     {
       // dirty_name = "...MT-...". Assume that we are dealing with a PostScript name
       // and the clean family name does not include the MT.
-      // Above we have explicity handled known clean family names that end in MT.
+      // Above we have explicitly handled known clean family names that end in MT.
       len -= 2;
     }
 
@@ -9062,7 +9062,7 @@ const ON_SHA1_Hash ON_Font::FontNameHash(
         if (font_name == (font_name0 + 13) && ON_wString::EqualOrdinal(L"MecSoft_Font-1", 14, font_name0, 14, true))
           continue;
 
-        // Single Line Font face names include the following. The hypen after SLF and the hyphen after RHN-
+        // Single Line Font face names include the following. The hyphen after SLF and the hyphen after RHN-
         // are part of the face name.
         // SLF-RHN-Architect
         // SLF-RHN-Industrial
@@ -9072,7 +9072,7 @@ const ON_SHA1_Hash ON_Font::FontNameHash(
         if (font_name == (font_name0 + 8) && ON_wString::EqualOrdinal(L"SLF-RHN-", 8, font_name0, 8, true))
           continue;
 
-        // Terminate hashing at this hypen because it separates the family name from the face name in a postscript name.
+        // Terminate hashing at this hyphen because it separates the family name from the face name in a postscript name.
         break;
       }
       continue;
@@ -9529,7 +9529,7 @@ bool ON_Font::SetFromFontDescription(
   // NOTE WELL: 
   //  It is important that local_face_name be created from a pointer
   //  so that it's string buffer is not shared with other ON_wStrings.
-  //  wchar_t values in local_face_name are modifed via const_cast<> below.
+  //  wchar_t values in local_face_name are modified via const_cast<> below.
   ON_wString local_face_name = static_cast<const wchar_t*>(font_description);
   const wchar_t* characteristics = nullptr;
   int face_name_length = local_face_name.Length();
@@ -11369,7 +11369,7 @@ unsigned int ON_Font::SetUnsetProperties(
     //   is is common for LOGFONT name to be used to distigush between weight
     //   and/or stretch in the same family.
     //   Generally, this situation is a result of LOGFONT GDI restrictions
-    //   and occures when a family has more than the four standard faces
+    //   and occurs when a family has more than the four standard faces
     //   (regular, bold, italic, bold-italic).
     //   Example:
     //      Family = "Arial"
@@ -11605,7 +11605,7 @@ bool ON_Font::IsOblique()
 void ON_Font::Internal_AfterModification(
 )
 {
-  // This occures when a characteristic like PostScriptName(), weight, facename, style is changed
+  // This occurs when a characteristic like PostScriptName(), weight, facename, style is changed
   // on a font that was original set from complete platform information.
   // It means the ON_Font may or may not have valid settings in platform specific
   // fields. In particular the Apple font name is typically no longer valid.
@@ -12884,7 +12884,7 @@ double ON_Font::PointSizeFromWindowsLogfontCharacterHeight(
     for (;;)
     {
       // Because LOGFONT lfHeight is an integer and point_size is typically
-      // an integer and sometimes a multiple of 0.5, the following rouding
+      // an integer and sometimes a multiple of 0.5, the following rounding
       // is performed so point_size will round trip.
       double i0 = floor(point_size);
       if (i0 == point_size)
@@ -13018,7 +13018,7 @@ bool ON_Font::SetFromWindowsLogFont(
     );
   }
 
-  // Do last because other setters sometimes unset the orgin.
+  // Do last because other setters sometimes unset the origin.
   SetFontOrigin(ON_Font::Origin::WindowsFont);
 
   return rc;
@@ -13634,9 +13634,9 @@ void ON_ManagedFonts::Internal_SetFakeWindowsLogfontNames(
   //
   // This all goes back to the 1970's and early user interfaces
   // that selected fonts based on a name, bold=true/false, italic=true/false
-  // style inteface. This type of archaic font selection interface is way 
-  // too simple to accomodate the rich font families are currently in use.
-  // Newer font families can have dozens of faces with severeal weights,
+  // style interface. This type of archaic font selection interface is way 
+  // too simple to accommodate the rich font families are currently in use.
+  // Newer font families can have dozens of faces with several weights,
   // several widths, and an upright and italic version of each of these.
   // However, that does not prevent applications like Rhino 6/7 
   // from attempting to use the inadequate and archic bold/italic font

--- a/opennurbs_font.h
+++ b/opennurbs_font.h
@@ -290,7 +290,7 @@ public:
 
   /*
   Returns:
-    The postive distance to move the base line when moving to a new line of text.
+    The positive distance to move the base line when moving to a new line of text.
 
   Remarks:
     For almost every font used to render English text, LineSpace() > (Ascent() - Descent()).
@@ -299,7 +299,7 @@ public:
     with (Ascent() - Descent()). 
 
     For fonts designed to render horizontal lines of text, LineSpace() is a 
-    vertical distance. For fonts desingned to render vertical lines of text,
+    vertical distance. For fonts designed to render vertical lines of text,
     LineSpace() is a horizontal distance.  Depending on the context, the 
     direction to move can be up, down, left or right.
 
@@ -354,7 +354,7 @@ public:
 
     If the capial height property of a font is not
     available, the ascent of I or H can be used instead. (There are
-    commonly used fonts where using other glpyhs gives undesirable results.)OfI.
+    commonly used fonts where using other glyphs gives undesirable results.)OfI.
 
     Windows: = DWRITE_FONT_METRICS.capHeight
     Apple: = CTFontGetAscent(...)
@@ -367,7 +367,7 @@ public:
     The font's typographic x-height.
 
   Remarks:
-    The x-height is used to help select a substitute font to use for missing glpyhs.
+    The x-height is used to help select a substitute font to use for missing glyphs.
   */
   int AscentOfx() const;
 
@@ -871,7 +871,7 @@ public:
 
     NotOriented = 3,
 
-    // An error occured in orientation calculations
+    // An error occurred in orientation calculations
     Error = 15
   };
 
@@ -886,7 +886,7 @@ public:
   {
     ///<summary>
     /// This value should be used for parameters where the type is has not
-    /// been explicity to determined.
+    /// been explicitly to determined.
     ///</summary>
     Unset = 0,
 
@@ -944,7 +944,7 @@ public:
     Opennurbs searches the description saved in field 10 of the name table
     for the strings "Engraving - single stroke" / "Engraving - double stroke" / "Engraving"
     to identify fonts that are desgned for engraving (and which tend to render poorly when
-    used to dispaly text devices like screens, monitors, and printers).
+    used to display text devices like screens, monitors, and printers).
     The SLF (single line fonts) are examples of fonts that have Engraving in field 10.
   Parameters:
     field_10_description - [in]
@@ -993,7 +993,7 @@ public:
       be set to what you plan on using when rendering the glyph.
       The orientation of outer_figur can be either clockwise or counterclockwise
       and, in the context of the entire glyph, outer_figure can be an inner or outer boundary.
-      For example, the registered trademark glpyh (UNICODE U+00AE) is an example where 
+      For example, the registered trademark glyph (UNICODE U+00AE) is an example where 
       four nested figures with alternating orientations are common.
     bPerformExtraChecking - [in]
       In general, when sorting glyph outlines as they come froma font file, set
@@ -1318,7 +1318,7 @@ public:
      figure outline bounding box.
      For example, the glyph metrics box for 1 (numeral one) often contains space beyond the
      glyph outline because 1 visually occupies the same space as a 2. The choice is up to the
-     font designer and takes into account the desired font asthetics of columns of numbers.
+     font designer and takes into account the desired font aesthetics of columns of numbers.
      */
   const ON_BoundingBox OutlineBoundingBox() const;
 
@@ -1330,7 +1330,7 @@ public:
      figure outline bounding box.
      For example, the glyph metrics box for 1 (numeral one) often contains space beyond the
      glyph outline because 1 visually occupies the same space as a 2. The choice is up to the
-     font designer and takes into account the desired font asthetics of columns of numbers.
+     font designer and takes into account the desired font aesthetics of columns of numbers.
   */
   const ON_TextBox GlyphMetrics() const;
 
@@ -1409,7 +1409,7 @@ private:
   // Unset = unsorted
   // CounterClockwise: outer figures are CCW
   // Clockwise: outer fitures are CW
-  // Error: error occured during sorting
+  // Error: error occurred during sorting
   mutable ON_OutlineFigure::Orientation m_sorted_figure_outer_orientation = ON_OutlineFigure::Orientation::Unset;
 
   ON__UINT8 m_reserved1 = 0;
@@ -1611,7 +1611,7 @@ public:
 
   /*
   Returns:
-    Number of input errors that have occured.
+    Number of input errors that have occurred.
   Remarks:
     When an error occurs, the current figure is terminated.
   */
@@ -1673,7 +1673,7 @@ public:
   const ON_OutlineFigurePoint ActiveFigureStartPoint() const;
 
   /*
-    Expert user tool for getting the curent point of 
+    Expert user tool for getting the current point of 
     the figure being accumulated.
   */
   const ON_OutlineFigurePoint ActiveFigureCurrentPoint() const;
@@ -1900,7 +1900,7 @@ public:
       When this->CodePointIsSet() is true, 
       and bUseReplacementCharacter is true,
       and no reasonable glyph definition exists,
-      and no substitued  is available, 
+      and no substitute  is available, 
       then the replacement character glyph for UNICODE code point
       ON_UnicodeCodePoint::ON_ReplacementCharacter (U+FFFD) will be returned.
 
@@ -1925,7 +1925,7 @@ public:
   Returns:
     If this is a managed glyph or a copy of a managed glyph, 
     and a substitute font or code point is used to render the glyph, 
-    then the substitue is returned.
+    then the substitute is returned.
     In all other cases, nullptr is returned.
   See Also:
     ON_FontGlyph.RenderGlyph().
@@ -1995,7 +1995,7 @@ public:
   Remarks:
     Many fonts do not have a glyph for a every UNICODE codepoint and font
     substitution is required. If you want to get the freetype face
-    used for a specfic UNICODE codepoint, call ON_Font::CodepointFreeTypeFace().
+    used for a specific UNICODE codepoint, call ON_Font::CodepointFreeTypeFace().
   */
   const ON__UINT_PTR FreeTypeFace() const;
 #endif
@@ -2029,7 +2029,7 @@ public:
     bSingleStrokeFont - [in]
       If true, open contours will not be closed by adding a line segment.
     height_of_capital - [in]
-      If > 0, ouptut curves, bounding box, and advance vector are scaled 
+      If > 0, output curves, bounding box, and advance vector are scaled 
       by height_of_capital/(font design capital height). For fonts like
       Arial, Helvetica, Times Roman, and Courier this means the height
       of H and I will be height_of_capital. 
@@ -2090,7 +2090,7 @@ private:
   //  FreeType made from the same LOGFONT on the same has height of Arial I = 184, height of LF = ...
 
   // When font does not contain a glyph to render  a specified unicode codepoint,
-  // then one or more glyphs from one or more subsitution fonts are used to
+  // then one or more glyphs from one or more substitution fonts are used to
   // render the codepoint. In this case, m_substitutes points to a linked
   // list of substitute used to render the glyph.
   //
@@ -2110,7 +2110,7 @@ private:
   void Internal_CopyFrom(const ON_FontGlyph& src);
   static ON_FontGlyph* Internal_AllocateManagedGlyph(const ON_FontGlyph& src);
   bool Internal_GetPlatformSubstitute(
-    ON_FontGlyph& substitue
+    ON_FontGlyph& substitute
   ) const;
 };
 
@@ -2141,9 +2141,9 @@ public:
 
   struct IDWriteFont* m_dwrite_font = nullptr;
 
-  // prefered locale used to get the localized name values. 
-  // If the a parrticular string was not available in the prefered locale, 
-  // then other locales are used with "en-us" being the prefered alternate locale.
+  // preferred locale used to get the localized name values. 
+  // If the a parrticular string was not available in the preferred locale, 
+  // then other locales are used with "en-us" being the preferred alternate locale.
   ON_wString m_prefered_locale;
 
   // from IDWriteFontFamily.GetFamilyNames()
@@ -2221,7 +2221,7 @@ public:
   // Opennurbs searches the description saved in field 10 of the name table
   // for the strings "Engraving - single stroke" / "Engraving - double stroke" / "Engraving"
   // to identify fonts that are desgned for engraving (and which tend to render poorly when
-  // used to dispaly text devices like screens, monitors, and printers).
+  // used to display text devices like screens, monitors, and printers).
   // The SLF (single line fonts) are examples of fonts that have Engraving in field 10.
   ON_wString m_loc_field_10_description;
   ON_wString m_en_field_10_description;
@@ -2257,7 +2257,7 @@ public:
 
   // Sample glyph metrics from IDWriteFontFace.GetDesignGlyphMetrics
 
-  // "standard" metric glpyhs
+  // "standard" metric glyphs
   ON_FontGlyph m_Spacebox;
   ON_FontGlyph m_Hbox;
   ON_FontGlyph m_Ibox;
@@ -2432,14 +2432,14 @@ public:
  #pragma region RH_C_SHARED_ENUM [ON_Font::Origin] [Rhino.DocObjects.Font.FontOrigin] [nested:byte]
   /// <summary>
   /// Platform where font originated. This information is useful when 
-  /// searching for appropriate substitues.
+  /// searching for appropriate substitutes.
   /// </summary>
   enum class Origin : unsigned char
   {
     /// <summary> Not set. </summary>
     Unset = 0,
 
-    /// <summary> Origin unknown. Changing an ON_Font characteristic like weight or sytle sets the origin to unknown. </summary>
+    /// <summary> Origin unknown. Changing an ON_Font characteristic like weight or style sets the origin to unknown. </summary>
     Unknown = 1,
 
     /// <summary> 
@@ -2460,7 +2460,7 @@ public:
 
 #pragma region RH_C_SHARED_ENUM [ON_Font::FontType] [Rhino.DocObjects.Font.FontType] [nested:byte]
   /// <summary>
-  /// An enum that reports if the font face is avaialable on the current device.
+  /// An enum that reports if the font face is available on the current device.
   /// </summary>
   enum class FontType : unsigned char
   {
@@ -2793,7 +2793,7 @@ public:
     Otherwise ON_FontFaceQuartet::Empty is returned.
     Note that managed font quartets can be enlarged to include missing faces by calling
     ON_Font::FontFromRichTextProperties(). Installed font quartets exactly match
-    what is installed on the current defice.
+    what is installed on the current device.
     if this font is not a member of an installed face quartet.
   */
   const ON_FontFaceQuartet FontQuartet() const;
@@ -3167,7 +3167,7 @@ public:
   Parameters:
     bAllowBestMatch - [in]
       If no exact match is available and bAllowBestMach is true and
-      there are installed fonts with a matching familiy name,
+      there are installed fonts with a matching family name,
       then the best match in the family is returned.
   Returns:
     If there is a matching installed font, it is returned.
@@ -3296,7 +3296,7 @@ public:
       (Strikethrough is created as a rendering effect and not a separate face.)
 
   Returns:
-    If there is an installed font, it is returned. Othewise a managed font
+    If there is an installed font, it is returned. Otherwise a managed font
     is returned. When the managed font is not installed, the corresponding
     member of ON_Font::Default::InstalledQuartet() is used to render the font.
   */
@@ -3346,7 +3346,7 @@ public:
 
   /*
   Description:
-    Returns the glpyh informationh for used to render a specific code point
+    Returns the glyph informationh for used to render a specific code point
   Parameters:
     unicode_code_point 
       UNICODE code point value
@@ -3354,7 +3354,7 @@ public:
     Glyph rendering information.
 
   Remarks:
-    Typically the returned glpyh uses is a single glpyh in this->ManagedFont().
+    Typically the returned glyph uses is a single glyph in this->ManagedFont().
     In this case, glyph->SubstitueCount() is 0.
 
     In some cases one or more glyphs from one or more substitute fonts are required
@@ -3398,7 +3398,7 @@ public:
 
   /*
   Description:
-    When reading version 5 3dm achives, the font description can be
+    When reading version 5 3dm archives, the font description can be
     a generic font description or an Apple font name. This function
     rejects certain descriptions like "Default" and "Arial" for
     use as Apple font names.
@@ -3599,7 +3599,7 @@ public:
   /*
   Returns:
     If this font is a managed font that references a font that is not installed on this computer,
-    then a pointer to the installed font that is the substitue for the missing font is returned.
+    then a pointer to the installed font that is the substitute for the missing font is returned.
     Otherwise nullptr is returned.
   */
   const ON_Font* SubstituteFont() const;
@@ -3779,7 +3779,7 @@ private:
     font_characteristics_as_unsigned - [in]
     Value returned from ON_Font.FontCharacteristicsAsUnsigned()
   Returns:
-    True if the characterstics were set.
+    True if the characteristics were set.
   Remarks:
     Used in 3dm archive reading/writing.
   */
@@ -3939,8 +3939,8 @@ public:
     For fonts that have at most 4 faces with the same stretch and variations
     in weight and slant, the  family_name is a good choice. 
     For fonts that have many faces, like Helvetica Neue on Mac OS,
-    this funciton will generate names that act like a Windows LOGFONT name
-    for use in archaic name + regular/bold/italic/bold-italic font selction
+    this function will generate names that act like a Windows LOGFONT name
+    for use in archaic name + regular/bold/italic/bold-italic font selection
     user interfaces.
   Returns:
     A fake windows logfont name.
@@ -4002,7 +4002,7 @@ public:
 
   /*
   Description:
-    Get a text descripton with family weight, width (stretch), slope (style).
+    Get a text description with family weight, width (stretch), slope (style).
   Parameters:
     family_separator - [in]
       character to place after family name in the description.
@@ -4036,7 +4036,7 @@ public:
 
   /*
   Description:
-    Get a text descripton with family weight, width (stretch), slope (style).
+    Get a text description with family weight, width (stretch), slope (style).
   Parameters:
     family_separator - [in]
       character to place after family name in the description.
@@ -4084,7 +4084,7 @@ private:
 public:
   /*
   Description:
-    Get the scale factors for converting heights beween 
+    Get the scale factors for converting heights between 
     Windows device coordinates and Windows logical coordinates.
 
   Parameters:
@@ -4118,7 +4118,7 @@ public:
     
     
     The Windows convention is to use negative lfHeight values to specify
-    font character heights and postive height values to specify font cell heights.
+    font character heights and positive height values to specify font cell heights.
 
     font cell height = font acsent + font descent.
 
@@ -4153,11 +4153,11 @@ public:
     = ascent + descent - internal leading
     For many common fonts, the "character height" is close to the distance
     from the bottom of a lower case g to the top of an upper case M. 
-    The internal leading is space reseved for diacritical marks like the
+    The internal leading is space reserved for diacritical marks like the
     ring above the A in the UNICODE "LATIN LETTER A WITH RING" U+00C5 glyph.
     Character height is also known as the "em height". 
     Note that the "em height" is typically larger than the height of the
-    letter M because "em height" inlcude descent.
+    letter M because "em height" include descent.
   */
   static int WindowsLogfontCharacterHeightFromPointSize(
     int map_mode,
@@ -4183,7 +4183,7 @@ public:
 
     logfont_character_height - [in]
       This value must be a Windows LOGFONT character height in units
-      determine from map_mode and hdc.  If you have a LOGFONT with postive
+      determine from map_mode and hdc.  If you have a LOGFONT with positive
       lfHeight value, you must get the fonts TEXTMETRICS and subbr
     
   Returns:
@@ -4339,7 +4339,7 @@ public:
         if ( nullptr != font_hdc )
         {
           ...
-          Calls to Windows SDK font managment functions needing an HDC
+          Calls to Windows SDK font management functions needing an HDC
           ...
           ON_Font::DeleteWindowsLogfontDeviceContext(font_hdc);
         }
@@ -4408,7 +4408,7 @@ public:
     Use the Windows GDI EnumFontFamiliesEx tool to get a list of LOGFONTS.
   Parameters:
     preferedLocale - [in]
-      If not empty, names from this locale will be prefered.
+      If not empty, names from this locale will be preferred.
       If preferedLocale = L"GetUserDefaultLocaleName", then
       ::GetUserDefaultLocaleName will be used to set the preferedLocale.
     bIncludeSimulatedFontFaces - [in]
@@ -4441,7 +4441,7 @@ public:
       GetDeviceCaps(hdc, LOGPIXELSY) and conversion between device and logical pixel heights
       DPtoLP(hdc,...) and LPtoDP(hdc,...) are used.
   Returns:
-    A Windows LOGFONT with propeties copied from this ON_Font.
+    A Windows LOGFONT with properties copied from this ON_Font.
     If WindowsLogFontIsComplete() is true, then all LOGFONT properties
     are copied from the ON_Font. 
     If WindowsLogFontIsComplete() is false, then the LOGFONT lfHeight,
@@ -4588,7 +4588,7 @@ public:
   Remarks:
     Many fonts do not have a glyph for a every UNICODE codepoint and font
     substitution is required. If you want to get the freetype face
-    used for a specfic UNICODE codepoint, call ON_Font::CodepointFreeTypeFace().
+    used for a specific UNICODE codepoint, call ON_Font::CodepointFreeTypeFace().
   */
   static ON__UINT_PTR FreeTypeFace(
     const ON_Font* font
@@ -4672,7 +4672,7 @@ public:
     postscript_name - [in]
     bAcceptPartialMatch - [in]
       If bAcceptPartialMatch is true, there is not a font on the device with a
-      matching name, but there are fonts with names that have siginificant overlap,
+      matching name, but there are fonts with names that have significant overlap,
       then the font with the best overlap is returned. 
       For example if "Arial-Black" is not present and "Arial-BoldMT" is present,
       then ON_Font.SetFromPostScriptName(L"Arial-Black",true) will return the
@@ -4685,7 +4685,7 @@ public:
   );
 
   /*
-  Paramaters:
+  Parameters:
     font_name - [in]
       A UTF-16 or UTF-32 encoded null terminated string.
     bStopAtHyphen - [in]
@@ -4716,7 +4716,7 @@ public:
   /*
   Description:
     Compare the font names ignoring hyphens, underbars, and spaces.
-  Paramaters:
+  Parameters:
     lhs - [in]
       font name to compare
     rhs - [in]
@@ -4736,7 +4736,7 @@ public:
   /*
   Description:
     Compare the font names ignoring hyphens, underbars, and spaces.
-  Paramaters:
+  Parameters:
     lhs - [in]
       font name to compare
     rhs - [in]
@@ -4756,7 +4756,7 @@ public:
   /*
   Description:
     Compare the font names ignoring hyphens, underbars, and spaces.
-  Paramaters:
+  Parameters:
     lhs - [in]
       font name to compare
     rhs - [in]
@@ -4778,7 +4778,7 @@ public:
     Compare the font names ignoring hyphens, underbars, and spaces.
     Ignore portions of PostScript names after the hyphen that separates the 
     font family and font face. 
-  Paramaters:
+  Parameters:
     lhs - [in]
       font name to compare
     rhs - [in]
@@ -4800,7 +4800,7 @@ public:
     Compare the font names ignoring hyphens, underbars, and spaces.
     Ignore portions of PostScript names after the hyphen that separates the
     font family and font face.
-  Paramaters:
+  Parameters:
     lhs - [in]
       font name to compare
     rhs - [in]
@@ -4822,7 +4822,7 @@ public:
     Compare the font names ignoring hyphens, underbars, and spaces.
     Ignore portions of PostScript names after the hyphen that separates the
     font family and font face.
-  Paramaters:
+  Parameters:
     lhs - [in]
       font name to compare
     rhs - [in]
@@ -4840,7 +4840,7 @@ public:
   );
 
   /*
-  Paramaters:
+  Parameters:
     dirty_font_name - [in]
       A UTF-16 or UTF-32 encoded null terminated string.
     map - [in]
@@ -4857,7 +4857,7 @@ public:
   Parameters:
     font - [in]
     bDefaultIfEmpty - [in]
-      If true and font is nullptr or has emtpy names, then
+      If true and font is nullptr or has empty names, then
       the rich text font name for ON_Font::Default is returned,
   Returns:
     Font name to use in rich text file fonttbl sections.
@@ -4888,7 +4888,7 @@ public:
       weight (Bold, Light, Heavy, ...), 
       width (Medium, Condensed, ...), 
       or slope (Oblique, Italic, Upright).
-      Generally, family names do NOT contain hyphens (like thos in PostScript names).
+      Generally, family names do NOT contain hyphens (like those in PostScript names).
 
       Apple: = CTFontCopyFamilyName() / NSFont.familyName
       Windows: = IDWriteFontFamily.GetFamilyNames()
@@ -4927,7 +4927,7 @@ public:
   Parameters:
     text_log - [in] if the object is not valid and text_log
         is not nullptr, then a brief englis description of the
-        reason the object is not valid is appened to the log.
+        reason the object is not valid is appended to the log.
         The information appended to text_log is suitable for 
         low-level debugging purposes by programmers and is 
         not intended to be useful as a high level user 
@@ -5013,11 +5013,11 @@ public:
     const wchar_t* preferedLocale
   );
 
-  // Returns the desription saved in field 10. 
+  // Returns the description saved in field 10. 
   // Opennurbs searches the description saved in field 10 of the name table
   // for the strings "Engraving - single stroke" / "Engraving - double stroke" / "Engraving"
   // to identify fonts that are desgned for engraving (and which tend to render poorly when
-  // used to dispaly text devices like screens, monitors, and printers).
+  // used to display text devices like screens, monitors, and printers).
   // The SLF (single line fonts) are examples of fonts that have Engraving in field 10.
   static const ON_wString Field_10_DescriptionFromWindowsDWriteFont(
     struct IDWriteFont* dwrite_font,
@@ -5053,11 +5053,11 @@ public:
   Parameters:
     dwrite_font - [in]
     preferedLocale - [in]
-      prefered local for strings (family name, font name, face name, postscript name, ...)
+      preferred local for strings (family name, font name, face name, postscript name, ...)
       A locale name often has the form "es-es", "en-us", ...
-      Pass nullptr or empty string list all locales and use "en-us" as the prefered locale name.
+      Pass nullptr or empty string list all locales and use "en-us" as the preferred locale name.
       (Most modern fonts distributed with Windows 10 in all locales have en-us names).
-      Pass "*..." if you want to list all locale names and specify a prefered locale.
+      Pass "*..." if you want to list all locale names and specify a preferred locale.
       For example, "*es-es" will list all local names but use "es-es" as the preferedLocale.
     text_log - [in]
       destintion for the text description of the font.
@@ -5225,7 +5225,7 @@ public:
     AnnotationFontApplePointSize = 256,
 
     // ON_Font::Constants::metric_char is the unicode code point value
-    // for the glpyh used to calculate critical glyph metrics.
+    // for the glyph used to calculate critical glyph metrics.
     // It must be an 'I' or 'H', but we have not tested 'H'.
     // There are problems with any other upper case latin letter in common fonts.
     // In particular, the standard 'M' does not work.
@@ -5266,7 +5266,7 @@ public:
 
     Fonts can be designed and defined at different resolutions and
     relative scaling is necessary when text contains glyphs from 
-    fonts desinged at different grid resolutions.  For example, 
+    fonts designed at different grid resolutions.  For example, 
     TrueType font grid with and height is often 1024x1024 or 
     2048x2014, OpenType grids are often 1000x1000, and PostScript 
     grids are often 1000x1000. Opennurbs "font units" are the units
@@ -5295,7 +5295,7 @@ public:
     scaling.
   Remarks:
     See ON_Font.FontMetrics() documentation for important information
-    about the differnce bewteen normalized and font unit metrics.
+    about the difference between normalized and font unit metrics.
   */
   const ON_FontMetrics& FontUnitFontMetrics() const;
 
@@ -5317,7 +5317,7 @@ public:
   Returns:
     Font character height in points (1 point = 1/72 inch).
 
-    See the remarks for a defintion of "character height".
+    See the remarks for a definition of "character height".
 
   Remarks:
     A "point" is a length unit system.
@@ -5333,10 +5333,10 @@ public:
     For fonts designed for languages that use latin letters, it is common for 
     the character height to be equal to or a little larger than the distance 
     from the bottom of a lower case g to the top of an upper case M. 
-    The character height is also called the "em hieght".
+    The character height is also called the "em height".
 
     Font internal leading is the space above typical capital latin letters
-    that is reseved for diacritical marks like the ring above the A in 
+    that is reserved for diacritical marks like the ring above the A in 
     the UNICODE "LATIN LETTER A WITH RING" U+00C5 glyph (Angstrom symbol).
   */
   double PointSize() const;
@@ -5479,7 +5479,7 @@ public:
   );
 
   /*
-  Paramaters:
+  Parameters:
     bCheckFamilyName - [in]
     bCheckPostScriptName - [in]
   Returns:
@@ -5496,7 +5496,7 @@ public:
 
   /*
   Description:
-    If a propery is unset in this and set in source, then it is set
+    If a property is unset in this and set in source, then it is set
     to the source value.
   Parameters:
     source - [in]
@@ -5761,7 +5761,7 @@ public:
   /*
   Description:
     The outlines for an engraving font have single-stroke, double-stroke, 
-    or perimeters desinged for path engraving. 
+    or perimeters designed for path engraving. 
     These fonts behave poorly when used for filled font rendering 
     or creating solid extrusions. 
     The OrachTech 2 line fonts are examples of engraving fonts that
@@ -5954,16 +5954,16 @@ private:
 
   //////////////////////////////////////////////////////////////////////////////////
   //
-  // The "font glpyh definition" parameters completely determine the appearance
+  // The "font glyph definition" parameters completely determine the appearance
   // of font glyphs.
   //
-  // If all "font glpyh definition" parameters have identical values, 
+  // If all "font glyph definition" parameters have identical values, 
   // text rendered using those fonts will look identical.
   //
-  // If two fonts have a "font glpyh definition" parameter with different values,
+  // If two fonts have a "font glyph definition" parameter with different values,
   // text rendered using those fonts will not look identical.
   //
-  // BEGIN "font glpyh definition" parameters:
+  // BEGIN "font glyph definition" parameters:
   //
 
   // The font ON_Font::Default has m_runtime_serial_number = 1.
@@ -6235,7 +6235,7 @@ public:
     font_characteristics_hash - [in]
     bReturnFirst - [in]
       If there are multiple fonts with the same hash and bReturnFirst is true,
-      then the first font with tht hash is returned.
+      then the first font with that hash is returned.
       If there are multiple fonts with the same hash and bReturnFirst is false,
       then nullptr is returned.
       new style or unset if font style is adequate
@@ -6345,7 +6345,7 @@ public:
     prefered_weight - [in]      
     prefered_stretch - [in]
     prefered_style - [in]
-      Prefered font properties.
+      Preferred font properties.
 
     bRequireFaceMatch - [in]
       If true and face_name is not empty, then the returned font 
@@ -6383,7 +6383,7 @@ public:
     prefered_weight - [in]      
     prefered_stretch - [in]
     prefered_style - [in]
-      Prefered font properties.
+      Preferred font properties.
 
     bRequireFaceMatch - [in]
       If true and face_name is not empty, then the returned font 
@@ -6523,7 +6523,7 @@ public:
   Remarks:
     This is pribarily for old-fashioned font selection UI that harkens back
     to the days of LOGFONT. The UI displays a name and a bold and italic button
-    that lets you select one of four releated faces. The name used to be based
+    that lets you select one of four related faces. The name used to be based
     on the LOGFONT name. Depending on the contents of the list, there may be 
     some faces in the list that do not appear in the QuartetList().
   */

--- a/opennurbs_fpoint.h
+++ b/opennurbs_fpoint.h
@@ -501,7 +501,7 @@ public:
   // Require explicit construction when dev must insure array has length >= 4.
   explicit ON_4fPoint(const float*);           // from float[4] array
 
-  // Require explicit construction when loosing precision
+  // Require explicit construction when losing precision
   explicit ON_4fPoint(const ON_2dPoint& );     // from 2d point
   explicit ON_4fPoint(const ON_3dPoint& );     // from 3d point
   explicit ON_4fPoint(const ON_4dPoint& );     // from 4d point

--- a/opennurbs_freetype.cpp
+++ b/opennurbs_freetype.cpp
@@ -356,7 +356,7 @@ ON_FreeTypeFace::~ON_FreeTypeFace()
 {
   //  FT_New_Memory_Face documentation states:
   //    You must not deallocate the memory before calling @FT_Done_Face.
-  //    The memory refered to is m_tt_file_buffer.
+  //    The memory referred to is m_tt_file_buffer.
   if (nullptr != m_face)
   {
     FT_Done_Face(m_face);
@@ -379,7 +379,7 @@ public:
     Finds the glyph id for the specified Unicode code point. When a non-zero
     glyph is is returned, the face->charmap is set to the charmap that was used
     to find the glyph. In some cases this is not a Unicode charmap and unicode_code_point
-    was internally coverted to a character code appropriate for the returned charmap.
+    was internally converted to a character code appropriate for the returned charmap.
     In principle, the glyph id for a Unicode code point is independent of the charmap.
   Returns:
      0: failure
@@ -558,7 +558,7 @@ bool ON_FreeType::UseUnicodeAsAppleRomanCharCode(FT_Face face)
   // glyph id.
   //
   // I have verified that the way opennurbs handles FT_ENCODING_APPLE_ROMAN charmaps
-  // and the funciton ON_MapUnicodeToAppleRoman() works correctly with all the
+  // and the function ON_MapUnicodeToAppleRoman() works correctly with all the
   // TTF fonts shipped with Windows 10 pro.
   //
   if (
@@ -883,7 +883,7 @@ bool ON_FontGlyph::TestFreeTypeFaceCharMaps(
       else if (0 == gid)
       {
         s += ON_wString::FormatToString(
-          L" no glpyh",
+          L" no glyph",
           char_code
         );
       }
@@ -960,13 +960,13 @@ unsigned int ON_FreeType::GlyphId(
   //  2-* ISO (encoding id = ISO encoding)
   //
   //  3-0 Windows Symbol
-  //  3-1 Wnidows UCS-2 (subset of Unicode)
+  //  3-1 Windows UCS-2 (subset of Unicode)
   //  3-2 Windows ShiftJIS
   //  3-3 Windows Big5
   //  3-4 WIndows PRC
   //  3-5 Windows Wansung
   //  3-6 Windows Johab
-  //  3-10 Wnidows UCS-4 (subset of Unicode)
+  //  3-10 Windows UCS-4 (subset of Unicode)
   //
   //  4-* Custom
   //
@@ -1060,7 +1060,7 @@ unsigned int ON_FreeType::GlyphId(
     }
   }
 
-  // No glpyh for this unicode code point is available.
+  // No glyph for this unicode code point is available.
   FT_Set_Charmap(face, charmap0);
 
   return 0;

--- a/opennurbs_freetype_include.h
+++ b/opennurbs_freetype_include.h
@@ -220,7 +220,7 @@
 //   FreeType 2.6.3 has deeply nested includes and uses angle brackets
 //   in its include files (instead of double quotes and relative paths like opennurbs),
 //   the directory ./freetype263/include must be in the "system" includes path.
-//   It is not feasable or reasonable for all projects that include opennurbs.h to have the
+//   It is not feasible or reasonable for all projects that include opennurbs.h to have the
 //   freetype includes directory in the system includes path.
 
 #if defined(OPENNURBS_FREETYPE_SUPPORT)

--- a/opennurbs_fsp.cpp
+++ b/opennurbs_fsp.cpp
@@ -11,7 +11,7 @@
 ON_FixedSizePool::ON_FixedSizePool()
 {
   ////const size_t sz = sizeof(*this);
-  ////ON_TextLog::Null.Print("L%d", sz); // supress compile errors.
+  ////ON_TextLog::Null.Print("L%d", sz); // suppress compile errors.
   // sz = 72 bytes before step 2 fixes for https://mcneel.myjetbrains.com/youtrack/issue/RH-49375
   //
   // private data members will be rearranged but the size cannot change so that the

--- a/opennurbs_fsp.h
+++ b/opennurbs_fsp.h
@@ -82,7 +82,7 @@ public:
       If you do not have a good estimate, then use zero.
     block_element_capacity - [in] (0 = good default)
       If block_element_capacity is zero, Create() will calculate a block
-      size that is efficent for most applications.  If you are an expert
+      size that is efficient for most applications.  If you are an expert
       user and want to specify the number of elements per block,
       then pass the number of elements per block here.  When
       block_element_capacity > 0 and element_count_estimate > 0, the first
@@ -292,7 +292,7 @@ public:
 
   /*
   Description:
-    Get the i-th elment in the fixed size pool.
+    Get the i-th element in the fixed size pool.
   Parameters:
     element_index - [in]
   Returns:
@@ -429,7 +429,7 @@ private:
 private:
   // Used by The ThreadSafe...() functions and for expert users 
   // to use when managing memory controlled by this pool. Best
-  // to ingnore this unless you have a very clear idea of what
+  // to ignore this unless you have a very clear idea of what
   // you are doing, why you are doing it, and when you are doing it.
   // Otherwise, you'll find yourself waiting forever on a nested
   // access request. 
@@ -554,7 +554,7 @@ public:
       If not null, the number of elements allocated from the
       first block is returned in block_element_count.
       Note that if you have used ReturnElement(), some
-      of these elemements may have been returned.
+      of these elements may have been returned.
   Example:
     The loop will iteratate through all the blocks.
 
@@ -594,7 +594,7 @@ public:
     block_element_count - [out] (can be null)
       If not null, the number of elements allocated from the
       block is returned in block_element_count.  Note that if
-      you have used ReturnElement(), some of these elemements
+      you have used ReturnElement(), some of these elements
       may have been returned.
   Example:
     See the FirstBlock() documentation.
@@ -631,7 +631,7 @@ public:
       If you do not have a good estimate, then use zero.
     block_element_count - [in] (0 = good default)
       If block_element_count is zero, Create() will calculate a block
-      size that is efficent for most applications.  If you are an expert
+      size that is efficient for most applications.  If you are an expert
       user and want to specify the number of blocks, then pass the number
       of elements per block here.  When block_element_count > 0 and
       element_count_estimate > 0, the first block will be large enough
@@ -725,7 +725,7 @@ public:
 
   /*
   Description:
-    Get the i-th elment in the pool.
+    Get the i-th element in the pool.
   Parameters:
     element_index - [in]
   Returns:
@@ -836,7 +836,7 @@ public:
 
   /*
   Description:
-    Sets the state of the iterator to the initail state that
+    Sets the state of the iterator to the initial state that
     exists after construction.  This is useful if the iterator
     has been used the get one or more elements and then
     the referenced fixed size pool is modified or code wants
@@ -854,7 +854,7 @@ public:
       If not null, the number of elements allocated from the
       first block is returned in block_element_count.
       Note that if you have used ReturnElement(), some
-      of these elemements may have been returned.
+      of these elements may have been returned.
   Example:
     The loop will iteratate through all the blocks.
 
@@ -894,7 +894,7 @@ public:
     block_element_count - [out] (can be null)
       If not null, the number of elements allocated from the
       block is returned in block_element_count.  Note that if
-      you have used ReturnElement(), some of these elemements
+      you have used ReturnElement(), some of these elements
       may have been returned.
   Example:
     See the FirstBlock() documentation.
@@ -907,7 +907,7 @@ public:
   T* NextBlock( size_t* block_element_count );
 
 private:
-  // no implementation (you can use a copy construtor)
+  // no implementation (you can use a copy constructor)
   class ON_SimpleFixedSizePoolIterator<T>& operator=(const class ON_SimpleFixedSizePoolIterator<T>&);
 };
 

--- a/opennurbs_geometry.cpp
+++ b/opennurbs_geometry.cpp
@@ -256,13 +256,13 @@ bool ON_Geometry::Transform( const ON_Xform& xform )
 
 bool ON_Geometry::HasBrepForm() const
 {
-  // override if specific geoemtry has brep form
+  // override if specific geometry has brep form
   return false;
 }
 
 ON_Brep* ON_Geometry::BrepForm(ON_Brep* brep) const
 {
-  // override if specific geoemtry has brep formw
+  // override if specific geometry has brep formw
   return nullptr;
 }
 

--- a/opennurbs_geometry.h
+++ b/opennurbs_geometry.h
@@ -271,7 +271,7 @@ public:
 
   /*
   Returns:
-    True if object can be accuratly modified with 
+    True if object can be accurately modified with 
     "squishy" transformations like projections, 
     shears, an non-uniform scaling.
   See Also:
@@ -283,7 +283,7 @@ public:
   /*
   Description:
     If possible, converts the object into a form that can
-    be accuratly modified with "squishy" transformations
+    be accurately modified with "squishy" transformations
     like projections, shears, an non-uniform scaling.
   Returns:
     False if object cannot be converted to a deformable

--- a/opennurbs_gl.cpp
+++ b/opennurbs_gl.cpp
@@ -3,7 +3,7 @@
 //
 // Copyright (c) 1993-2011 Robert McNeel & Associates. All rights reserved.
 // OpenNURBS, Rhinoceros, and Rhino3D are registered trademarks of Robert
-// McNeel & Assoicates.
+// McNeel & Associates.
 //
 // THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY.
 // ALL IMPLIED WARRANTIES OF FITNESS FOR ANY PARTICULAR PURPOSE AND OF

--- a/opennurbs_gl.h
+++ b/opennurbs_gl.h
@@ -43,7 +43,7 @@
 // Tested compilers:
 //   Apple Xcode 2.4.1
 //   Support for other Apple compilers is not available.
-#include <GLUT/glut.h>   // Open GL auxillary functions
+#include <GLUT/glut.h>   // Open GL auxiliary functions
 
 #else
 
@@ -152,10 +152,10 @@ void ON_GL(
       int = 1,           // bPermitKnotScaling - If true, surface knots may
                          // be rescaled to avoid knot vectors GL cannot handle.
       double* = nullptr,    // knot_scale0[2] - If not nullptr and bPermitKnotScaling,
-                         // the scaleing applied to the first parameter is
+                         // the scaling applied to the first parameter is
                          // returned here.
       double* = nullptr     // knot_scale0[2] - If not nullptr and bPermitKnotScaling,
-                         // the scaleing applied to the second parameter is
+                         // the scaling applied to the second parameter is
                          // returned here.
       );
 

--- a/opennurbs_glyph_outline.cpp
+++ b/opennurbs_glyph_outline.cpp
@@ -226,7 +226,7 @@ void ON_Outline::SortFigures(
   // all of which attempted to take into account the orientations from the font file. 
   // It is so common for the orientations in the font files to be wrong, 
   // that ignoring them is the most efficient and reliable approach to date.
-  // It is extremly common for outer figures to overlap.
+  // It is extremely common for outer figures to overlap.
   ON_SimpleArray<ON_OutlineFigure*> outer_figures(sorted_figure_count);
   ON_SimpleArray<ON_OutlineFigure*> inner_figures(sorted_figure_count);
   ON_SimpleArray<ON_OutlineFigure*> inner_figures_parent(sorted_figure_count);
@@ -905,9 +905,9 @@ static bool Internal_ExtraInsideOfPolylineText(
         alpha[0] * B[1].x + alpha[1] * B[1].y + alpha[2]
       };
       if (h[0] < 0.0 && h[1] < 0.0)
-        continue; // B[0] and B[1] on same side of infinte line through A[0],A[1]
+        continue; // B[0] and B[1] on same side of infinite line through A[0],A[1]
       if (h[0] > 0.0 && h[1] > 0.0)
-        continue; // B[0] and B[1] on same side of infinte line through A[0],A[1]
+        continue; // B[0] and B[1] on same side of infinite line through A[0],A[1]
 
       const double beta[3] =
       {
@@ -919,9 +919,9 @@ static bool Internal_ExtraInsideOfPolylineText(
       h[0] = beta[0] * B[0].x + beta[1] * B[0].y + beta[2];
       h[1] = beta[0] * B[1].x + beta[1] * B[1].y + beta[2];
       if (h[0] < 0.0 && h[1] < 0.0)
-        continue; // A[0] and A[1] on same side of infinte line through B[0],B[1]
+        continue; // A[0] and A[1] on same side of infinite line through B[0],B[1]
       if (h[0] > 0.0 && h[1] > 0.0)
-        continue; // A[0] and A[1] on same side of infinte line through B[0],B[1]
+        continue; // A[0] and A[1] on same side of infinite line through B[0],B[1]
 
       // The line segment A[0],A[1] and line segment B[0],B[1] intersect someplace.
       // The location of the intersection doesn't matter, even if it's one of the end points.
@@ -992,7 +992,7 @@ bool ON_OutlineFigure::IsInsideOf(
     // The context that calls this function is sorting nested loops.
     // The orientation of outer_figure has been decided and set at this point.
     // When this orientation of this is not different, we need more checking
-    // to verify that the orientaion from the font definition file was really "wrong".
+    // to verify that the orientation from the font definition file was really "wrong".
     // The "A crossbar" in Bahnschrift U+00C5 is one of many cases that
     // require this additional checking. More generally, glyphs with
     // orientations set correctly and which use overlapping outer 
@@ -1207,7 +1207,7 @@ bool ON_OutlineFigure::ReverseFigure()
   {
     if ( false == a[i].IsInteriorFigurePoint() )
     {
-      // a[] containts errors, unsets, or embedded figures
+      // a[] contains errors, unsets, or embedded figures
       return error_rc;
     }
   }

--- a/opennurbs_hash_table.h
+++ b/opennurbs_hash_table.h
@@ -46,7 +46,7 @@ public:
     If this item has been added to an ON_Hash32Table.AddItem(hash32,item pointer) then the 
     value of hash3d passed as the first argument to ON_Hash32Table.AddItem(hash32,item pointer)
     is returned. This is the value the ON_Hash32Table uses for this item.
-    Othewise 0 is returned.
+    Otherwise 0 is returned.
   Remarks:
     This function is useful when copying hash tables.
 
@@ -132,7 +132,7 @@ public:
   Returns:
     The first item in the hash table.
   Remarks:
-    This function is used for iterating throught every element in the hash table.
+    This function is used for iterating through every element in the hash table.
   */
   class ON_Hash32TableItem* FirstTableItem(
     ) const;
@@ -141,7 +141,7 @@ public:
   Returns:
     The next item in the hash table.
   Remarks:
-    This function is used for iterating throught every element in the hash table.
+    This function is used for iterating through every element in the hash table.
   */
   class ON_Hash32TableItem* NextTableItem(
     const ON_Hash32TableItem* item

--- a/opennurbs_hatch.cpp
+++ b/opennurbs_hatch.cpp
@@ -353,7 +353,7 @@ static bool Internal_UseHatchReadV5(
     )
   {
     // new hatch IO code pushed to master branch on Feb 26, 2016.
-    // THis clunky test has to be used on files writting with the Feb 26, 2016 version of opennurbs source code.
+    // THis clunky test has to be used on files writing with the Feb 26, 2016 version of opennurbs source code.
     ON__UINT32 tcode = 0;
     ON__INT64 big_value = 0;
     archive.PeekAt3dmBigChunkType(&tcode, &big_value);

--- a/opennurbs_hatch.h
+++ b/opennurbs_hatch.h
@@ -255,7 +255,7 @@ public:
     Get the number of gaps + dashes in the line
   Parameters:
   Return:
-    nummber of dashes in the line
+    number of dashes in the line
   */
   int DashCount() const;
 

--- a/opennurbs_input_libsdir.h
+++ b/opennurbs_input_libsdir.h
@@ -20,7 +20,7 @@
 
 // This header file insures OPENNURBS_INPUT_LIBS_DIR is defined to be
 // the path to were the libraries opennurbs.dll links with are located.
-// Examples of these libaries are zlib and freetype.
+// Examples of these libraries are zlib and freetype.
 
 #if defined(OPENNURBS_OUTPUT_DIR)
 // Typically, OPENNURBS_OUTPUT_DIR is defined in the 

--- a/opennurbs_instance.cpp
+++ b/opennurbs_instance.cpp
@@ -219,9 +219,9 @@ private:
 
 private:
   // When a component (layer, material, ...) from a linked file is inserted in the 
-  // active model and a component id collision occures, the active model id of the 
+  // active model and a component id collision occurs, the active model id of the 
   // component has to be changed. This list keeps track of the changes so we can 
-  // determine which runtime component correspondes to a component in the linked file. 
+  // determine which runtime component corresponds to a component in the linked file. 
   // The first id in the pair is component id in the linked reference file.
   // The second id in the pair is the component id in the runtime model.
   //
@@ -603,7 +603,7 @@ void ON_ReferencedComponentSettingsImpl::BeforeLinkedDefinitionWriteImpl(
 
     ON_Layer* ref_model_layer_copy = new ON_Layer(*model_layer);
     // The runtime index and id commonly change every time the file is read,
-    // so saving this varaible runtime identification information
+    // so saving this variable runtime identification information
     // leads to confusion.
     ref_model_layer_copy->ClearName();
     ref_model_layer_copy->ClearIndex();
@@ -1504,7 +1504,7 @@ bool ON_InstanceDefinition::SetInstanceDefinitionType(
     }
     else
     {
-      ON_ERROR("Invalid instance_definition_type parameter. Use SetLinkedFilePath() to create linked instance defintions.");
+      ON_ERROR("Invalid instance_definition_type parameter. Use SetLinkedFilePath() to create linked instance definitions.");
       rc = false;
     }
     break;
@@ -1520,7 +1520,7 @@ bool ON_InstanceDefinition::SetInstanceDefinitionType(
     }
     else
     {
-      ON_ERROR("Invalid instance_definition_type parameter. Use SetLinkedFilePath() to create linked instance defintions.");
+      ON_ERROR("Invalid instance_definition_type parameter. Use SetLinkedFilePath() to create linked instance definitions.");
       rc = false;
     }
     break;
@@ -1944,7 +1944,7 @@ bool ON_ReferencedComponentSettingsImpl::ReadImpl(
 
   m_bHasReferenceLayerTableParentLayer = (nullptr != m_layer_table_parent_layer);
 
-  // Prior to August 2017, a bug was saving per view sttings that applied to the 
+  // Prior to August 2017, a bug was saving per view settings that applied to the 
   // reference model. This for loop will delete those settings
   for (int i = 0; i < m_layer_referenced_file_copy.Count(); i++)
   {
@@ -2079,8 +2079,8 @@ ON_ReferencedComponentSettings* ON_InstanceDefinition::LinkedIdefReferenceCompon
 ///////////////////////////////////////////////////////////////////
 class /*NEVER EXPORT THIS CLASS DEFINITION*/ ON_OBSOLETE_IDefAlternativePathUserData : public ON_UserData
 {
-  // USED IN V4 and V5 files to save relative paths tol linked files.
-  // In V6 and later this information is in the m_linked_file_relative_path memember.
+  // USED IN V4 and V5 files to save relative paths to linked files.
+  // In V6 and later this information is in the m_linked_file_relative_path member.
   ON_OBJECT_DECLARE(ON_OBSOLETE_IDefAlternativePathUserData);
 
 public:
@@ -2157,7 +2157,7 @@ bool ON_OBSOLETE_IDefAlternativePathUserData::DeleteAfterRead(
   ) const
 {
   // This user data is read from V4 and V5 files and is then deleted after
-  // the information is transfered to idef->m_linked_file_reference.
+  // the information is transferred to idef->m_linked_file_reference.
   for (;;)
   {
     ON_InstanceDefinition* idef = ON_InstanceDefinition::Cast(parent_object);

--- a/opennurbs_instance.h
+++ b/opennurbs_instance.h
@@ -43,7 +43,7 @@ public:
   /*
   Description:
     Update runtime layer color visibility, locked, ... settings in the
-    layer table read from a refence file to the values to use in the
+    layer table read from a reference file to the values to use in the
     runtime model.
     This is typically done right after the reference file layer table is
     read and before the layers are added to the runtime model.
@@ -151,7 +151,7 @@ public:
 
   // IDEF_UPDATE_TYPE lists the possible relationships between
   // the instance definition geometry and the archive 
-  // (m_source_archive) containing the original defition.
+  // (m_source_archive) containing the original definition.
   enum class IDEF_UPDATE_TYPE : unsigned int
   {
     Unset = 0,
@@ -164,13 +164,13 @@ public:
     //embedded_def = 1,
     //  // As of 7 February, "static_def" and "embedded_def" 
     //  // and shall be treated the same. Using "static_def"
-    //  // is prefered and "embedded_def" is obsolete.
+    //  // is preferred and "embedded_def" is obsolete.
     //  // The geometry for the instance definition
     //  // is saved in archives, is fixed and has no
     //  // connection to a source archive.
     //  // All source archive information should be
     //  // empty strings and m_source_archive_checksum
-    //  // shoule be "zero".
+    //  // should be "zero".
     //linked_and_embedded_def = 2,
     //  // The geometry for the instance definition
     //  // is saved in archives.  Complete source
@@ -198,7 +198,7 @@ public:
     unsigned int idef_type_as_unsigned
     );
 
-  // Bits that identify subsets of the instance defintion
+  // Bits that identify subsets of the instance definition
   // fields. These bits are used to determine which fields to
   // set when an ON_InstanceDefinition class is used to
   // modify an existing instance definition.
@@ -466,7 +466,7 @@ public:
 
   /*
   Description:
-    This property applies when an instance definiton is linked.
+    This property applies when an instance definition is linked.
   Returns:
     true:
       When reading the file that defines the content of the linked instance definition,
@@ -501,7 +501,7 @@ private:
   //  To avoid having to deal with this obsolete type in
   //  your code, using ON_InstanceDefintion::IdefUpdateType()
   //  to get this value.  The IdefUpdateType() function
-  //  with convert the obsolte value to the correct
+  //  with convert the obsolete value to the correct
   //  value.
   ON_InstanceDefinition::IDEF_UPDATE_TYPE m_idef_update_type = ON_InstanceDefinition::IDEF_UPDATE_TYPE::Static; 
 
@@ -535,7 +535,7 @@ public:
   
   /// <summary>
   /// ON_InstanceDefinition::LinkedComponentStates specifies how model components
-  /// (layers, materials, dimension styles, ...) from linked instance defintion files
+  /// (layers, materials, dimension styles, ...) from linked instance definition files
   /// are appear in the active model.
   /// </summary>  
   enum class eLinkedComponentAppearance : unsigned char
@@ -585,7 +585,7 @@ public:
 
   /*
   Returns:
-    A SHA-1 hash of these instance defintions properties:   
+    A SHA-1 hash of these instance definitions properties:   
 
     InstanceGeometryIdList()
     BoundingBox()
@@ -598,7 +598,7 @@ public:
 
   /*
   Returns:
-    A SHA-1 hash of these instance defintions properties
+    A SHA-1 hash of these instance definitions properties
     Description()
     URL()
     URL_Tag()
@@ -755,7 +755,7 @@ private:
   // linked instance definition.
   //
   // For example, if 
-  // idefA = linked instance defintion referencing file A.
+  // idefA = linked instance definition referencing file A.
   // idefX = any type of instance definition found in idefA.
   // 
   // iref = model geometry reference to idefX.

--- a/opennurbs_internal_V2_annotation.cpp
+++ b/opennurbs_internal_V2_annotation.cpp
@@ -28,7 +28,7 @@
 #include "opennurbs_internal_V2_annotation.h"
 #include "opennurbs_internal_V5_annotation.h"
 
-// This define is up here so anybody who want's to defeat the
+// This define is up here so anybody who wants to defeat the
 // bozo vaccine has to be doing it on purpose.
 #define BOZO_VACCINE_699FCC4262D4488c9109F1B7A37CE926
 
@@ -884,7 +884,7 @@ bool ON_OBSOLETE_V5_Annotation::Write( ON_BinaryArchive& file ) const
 
     // June 17, 2010 - Lowell - Added adjustment to position text
     // a little better in pre-v5 files.
-    // There's no adjustment for right/left justify becasue we don't 
+    // There's no adjustment for right/left justify because we don't 
     // know the width of the text here
     // This doesn't change the size or position of any fields being
     // written, but just adjusts the plane to tune up the alignment
@@ -945,7 +945,7 @@ bool ON_OBSOLETE_V5_Annotation::Write( ON_BinaryArchive& file ) const
     case ON_INTERNAL_OBSOLETE::V5_eAnnotationType::dtDimRadius:
     case ON_INTERNAL_OBSOLETE::V5_eAnnotationType::dtDimDiameter:
       // 9 August 2005 Dale Lear - radial dimensions do
-      // not support user postioned text.  The never have
+      // not support user positioned text.  The never have
       // in Rhino, but the old files had 5 points in them.
       if ( 4 == points.Count() )
       {
@@ -1146,7 +1146,7 @@ bool ON_OBSOLETE_V5_Annotation::Read( ON_BinaryArchive& file )
     case ON_INTERNAL_OBSOLETE::V5_eAnnotationType::dtDimRadius:
     case ON_INTERNAL_OBSOLETE::V5_eAnnotationType::dtDimDiameter:
       // 9 August 2005 Dale Lear - radial dimensions do
-      // not support user postioned text.  The never have
+      // not support user positioned text.  The never have
       // in Rhino, but the old files had 5 points in them.
       if ( 5 == m_points.Count() )
       {
@@ -2110,7 +2110,7 @@ bool ON_OBSOLETE_V5_DimLinear::GetTightBoundingBox(
 int ON_OBSOLETE_V5_DimLinear::Repair()
 {
   // returns 0 = unable to repair
-  //         1 = in perfect condtion
+  //         1 = in perfect condition
   //         2 == repaired.
 
   const int ext0_pt_index   = ON_OBSOLETE_V5_DimLinear::ext0_pt_index;
@@ -3180,7 +3180,7 @@ public:
 
   // offsets from apex of dimension to point from which extension lines start
   // if these are < 0.0, they are ignored
-  // Extension lines are drawn from theses points to the Arrow tip points
+  // Extension lines are drawn from these points to the Arrow tip points
   // subject to dimexe & dimexo & dimse1 & dimse2
   double m_dimpoint_offset[2];
 };

--- a/opennurbs_internal_V5_annotation.h
+++ b/opennurbs_internal_V5_annotation.h
@@ -567,7 +567,7 @@ public:
   Remarks:
     This gets the literal value of the text, there is no
     substitution for any "<>" substrings.  When a dimension
-    is drawn, any occurance of "<>" will be replaced
+    is drawn, any occurrence of "<>" will be replaced
     with the measured value for the dimension and formatted
     according to the DimStyle settings.
 
@@ -955,7 +955,7 @@ private:
   // At this point, the ON_OBSOLETE_V5_Annotation and derived classes
   // exists for a single purpose - to support reading and writing
   // V5 (4,3,2) 3dm archives. 
-  // In V5 archives all dimension styles, including per opbject overrrides
+  // In V5 archives all dimension styles, including per object overrides
   // were in the archive dimstyle table. In V6 and later, override dimstyles
   // are managed by the object that uses them.
   //
@@ -1045,7 +1045,7 @@ public:
   Parameters:
     V6_dim_linear -[in]
     annotation_context - [in]
-      Dimstyle and other informtion referenced by V6_dim_linear or nullptr if not available.
+      Dimstyle and other information referenced by V6_dim_linear or nullptr if not available.
     destination - [in]
       If destination is not nullptr, then the V5 linear dimension is constructed
       in destination. If destination is nullptr, then the new V5 linear dimension
@@ -1103,13 +1103,13 @@ public:
        int point_index
        ) const;
 
-  // overrides virual ON_Object::IsValid
+  // overrides virtual ON_Object::IsValid
   bool IsValid( ON_TextLog* text_log = nullptr ) const override;
 
-  // overrides virual ON_Object::Write
+  // overrides virtual ON_Object::Write
   bool Write(ON_BinaryArchive&) const override;
 
-  // overrides virual ON_Object::Read
+  // overrides virtual ON_Object::Read
   bool Read(ON_BinaryArchive&) override;
 
   // virtual ON_Geometry GetBBox override		
@@ -1284,13 +1284,13 @@ public:
        ) const;
 
 
-  // overrides virual ON_Object::IsValid
+  // overrides virtual ON_Object::IsValid
   bool IsValid( ON_TextLog* text_log = nullptr ) const override;
 
-  // overrides virual ON_Object::Write
+  // overrides virtual ON_Object::Write
   bool Write(ON_BinaryArchive&) const override;
 
-  // overrides virual ON_Object::Read
+  // overrides virtual ON_Object::Read
   bool Read(ON_BinaryArchive&) override;
 
   // virtual ON_Geometry GetBBox override		
@@ -1326,7 +1326,7 @@ public:
     Overrides virtual ON_OBSOLETE_V5_Annotation::NumericValue();
   Returns:
     If m_type is ON_INTERNAL_OBSOLETE::V5_eAnnotationType::dtDimDiameter, then the diameter
-    is returned, othewise the radius is returned.
+    is returned, otherwise the radius is returned.
   */
   double NumericValue() const override;
 
@@ -1475,7 +1475,7 @@ public:
        ) const;
 
 
-  // overrides virual ON_Object::IsValid
+  // overrides virtual ON_Object::IsValid
   bool IsValid( ON_TextLog* text_log = nullptr ) const override;
 
   // virtual ON_Geometry GetBBox override		
@@ -1756,7 +1756,7 @@ public:
        double default_offset = 1.0
        ) const;
 
-  // overrides virual ON_Object::IsValid
+  // overrides virtual ON_Object::IsValid
   bool IsValid( ON_TextLog* text_log = nullptr ) const override;
 
   // virtual ON_Geometry GetBBox override		
@@ -1917,15 +1917,15 @@ public:
     ON_OBSOLETE_V5_TextObject* destination
   );
 
-  // overrides virual ON_Object::IsValid
+  // overrides virtual ON_Object::IsValid
   // Text entities with strings that contain no "printable" characters
   // are considered to be NOT valid.
   bool IsValid( ON_TextLog* text_log = nullptr ) const override;
 
-  // overrides virual ON_Object::Write
+  // overrides virtual ON_Object::Write
   bool Write(ON_BinaryArchive&) const override;
 
-  // overrides virual ON_Object::Read
+  // overrides virtual ON_Object::Read
   bool Read(ON_BinaryArchive&) override;
 
   // overrides virtual ON_Geometry::Transform()
@@ -2077,13 +2077,13 @@ public:
        int point_index
        ) const;
 
-  // overrides virual ON_Object::IsValid
+  // overrides virtual ON_Object::IsValid
   bool IsValid( ON_TextLog* text_log = nullptr ) const override;
 
-  // overrides virual ON_Object::Write
+  // overrides virtual ON_Object::Write
   bool Write(ON_BinaryArchive&) const override;
 
-  // overrides virual ON_Object::Read
+  // overrides virtual ON_Object::Read
   bool Read(ON_BinaryArchive&) override;
 
   // virtual ON_Geometry GetBBox override		

--- a/opennurbs_internal_V5_dimstyle.cpp
+++ b/opennurbs_internal_V5_dimstyle.cpp
@@ -48,7 +48,7 @@ can have their own copy of a dimension style to override some settings
 
   When a value is changed in a parent dimstyle, it should look through the other 
   dimstyles in the dimstyle table (or your application's equivalent) and change any 
-  of its children appropriately.  Name and Index fields aren't propogated this way.
+  of its children appropriately.  Name and Index fields aren't propagated this way.
   If the parent's field being changed is not set in the child's m_valid_fields array,
   the child's copy of that field should be changed to match the parent's new value.
   Changing values in child dimstyles doesn't change values in their parents.
@@ -945,7 +945,7 @@ bool ON_V5x_DimStyle::Read(
   // ON_V5x_DimStyle::Default cannot be a static member
   // because we cannot control order of static initialization on Mac / Clang
   // and all public statics in opennurbs_statics.cpp need to be initialized
-  // before the obsolete ON_V5x_DimStyle can be initialzed.
+  // before the obsolete ON_V5x_DimStyle can be initialized.
   // The ON_V5x_DimStyle::Default() function is called only when files are 
   // read and by that time ON_DimStyle::Default exists.
   const ON_V5x_DimStyle unset_dimstyle(ON::LengthUnitSystem::None, ON_DimStyle::Unset);
@@ -1015,7 +1015,7 @@ bool ON_V5x_DimStyle::Internal_Read_v6(
     if (minor_version >= 2)
     {
       if (rc) rc = file.ReadDouble(&m_lengthfactor);
-      // assume length factor value was junk from buggy .NET user inteface 
+      // assume length factor value was junk from buggy .NET user interface 
       m_lengthfactor = 1.0;
 
       if (rc) rc = file.ReadString(m_prefix);
@@ -1234,7 +1234,7 @@ void ON_Internal_FixBogusDimStyleLengthFactor(
     if (version_day_of_month >= 6)
       return; // July 6, 2017 through July 31, 2017
   }
-  dimstyle_length_factor = 1.0; // fix junky value written from Jan 1, 2017 throught July 5, 2017
+  dimstyle_length_factor = 1.0; // fix junky value written from Jan 1, 2017 through July 5, 2017
 }
 
 bool ON_V5x_DimStyle::Internal_Read_v5(

--- a/opennurbs_internal_V5_dimstyle.h
+++ b/opennurbs_internal_V5_dimstyle.h
@@ -393,7 +393,7 @@ public:
 
   // Change the fields in this dimstyle to match the fields of the 
   // source dimstyle for all of the fields that are marked overridden in the source
-  // and to match the parent for all of the fields not marked overriden.
+  // and to match the parent for all of the fields not marked overridden.
   // Returns true if any overrides were set.
   bool OverrideFields( const ON_V5x_DimStyle& source, const ON_V5x_DimStyle& parent);
 

--- a/opennurbs_internal_Vx_annotation.cpp
+++ b/opennurbs_internal_Vx_annotation.cpp
@@ -26,7 +26,7 @@
 /////////////////////////////////////////////////////////////////////////////
 //
 // This file contains code that translates current annotation object
-// defintions to and from obsolete V2 and V5 annotation object definitions.
+// definitions to and from obsolete V2 and V5 annotation object definitions.
 // This code is used to read and write old file formats.
 
 

--- a/opennurbs_internal_unicode_cp.h
+++ b/opennurbs_internal_unicode_cp.h
@@ -52,7 +52,7 @@
 // When possible, Rhino and opennurbs replace code page 
 // encodings with UNICODE in RTF. All runtimes strings
 // use UNICODE UTF-8, UTF-16, or UTF-32 encodings.
-// Whenever posssible, the UNICODE encoding is used
+// Whenever possible, the UNICODE encoding is used
 // to retrieve glyph information from fonts.
 #define ON_DOUBLE_BYTE_CODE_PAGE_SUPPORT
 #endif
@@ -76,7 +76,7 @@ bool ON_IsPotentialWindowsCodePage932DoubleByteEncoding(
 /*
 Description:
   Convert a Windows code page 932 encoded value to a UNICODE code point.
-  This code page is often used for Japanese glpyhs.
+  This code page is often used for Japanese glyphs.
 
 Parameters:
   code_page_932_character_value - [in]
@@ -119,7 +119,7 @@ bool ON_IsPotentialWindowsCodePage949DoubleByteEncoding(
 /*
 Description:
   Convert a Windows code page 949 encoded value to a UNICODE code point.
-  This code page is often used for Korean glpyhs.
+  This code page is often used for Korean glyphs.
 
 Parameters:
   code_page_949_character_value - [in]

--- a/opennurbs_intersect.cpp
+++ b/opennurbs_intersect.cpp
@@ -69,7 +69,7 @@ bool ON_Intersect( const ON_BoundingBox& bbox,
   ON_3dVector v = line.Direction();
   const int i = v.MaximumCoordinateIndex();
 
-  // gaurd against ON_UNSET_VALUE as input
+  // guard against ON_UNSET_VALUE as input
   if ( !(tol >= 0.0) )
     tol = 0.0;
 
@@ -1047,11 +1047,11 @@ int ON_Intersect( const ON_Sphere& sphere0,
     return 3;//Same sphere.
   }
 
-  //Spheres are appart.
+  //Spheres are apart.
   if (d > r0 + r1)
     return 0;
 
-  //Spheres tangent and appart
+  //Spheres tangent and apart
   if (d == r0+r1){
     ON_3dPoint P = C0 + r0*D;
     circle.Create(P, 0.0);

--- a/opennurbs_intersect.h
+++ b/opennurbs_intersect.h
@@ -79,7 +79,7 @@ bool ON_IntersectLineLine(
 
 /*
 Description:
-  Find the closest point between two infinte lines.
+  Find the closest point between two infinite lines.
 Parameters:
   lineA - [in]
   lineB - [in]
@@ -131,7 +131,7 @@ Parameters:
     line segment between line.from and line.to
     does not intersect the plane.
 Returns:
-  true if the interesection is a singe point.
+  true if the intersection is a single point.
   and false otherwise.
   If returned parameter is < 0 or > 1, then the line
   segment between line.m_point[0] and line.m_point[1]

--- a/opennurbs_ipoint.h
+++ b/opennurbs_ipoint.h
@@ -63,7 +63,7 @@ public:
 public:
   /*
   For those times when a location was incorrectly represented by a vector.
-  It is intentional that ther is not an ON_2iPoint constructor from an ON_2iVector.
+  It is intentional that there is not an ON_2iPoint constructor from an ON_2iVector.
   */
   static const ON_2iPoint FromVector(const class ON_2iVector& v);
 
@@ -122,7 +122,7 @@ public:
   
   /*
   For those times when a direction was incorrectly represented by a point.
-  It is intentional that ther is not an ON_2iVector constructor from an ON_2iPoint.
+  It is intentional that there is not an ON_2iVector constructor from an ON_2iPoint.
   */
   static const ON_2iVector FromPoint(const class ON_2iPoint& p);
 

--- a/opennurbs_knot.cpp
+++ b/opennurbs_knot.cpp
@@ -223,7 +223,7 @@ int ON_NurbsSpanIndex(
     j = len-2;
   else if (side < 0) {
     // if user wants limit from below and t = an internal knot,
-    // back up to prevous span
+    // back up to previous span
     while(j > 0 && t == knot[j]) 
       j--;
   }

--- a/opennurbs_knot.h
+++ b/opennurbs_knot.h
@@ -233,7 +233,7 @@ bool ON_IsValidKnotVector(
 
 ON_DECL
 bool ON_ClampKnotVector(
-          // Sets inital/final order-2 knots to values in
+          // Sets initial/final order-2 knots to values in
           // knot[order-2]/knot[cv_count-1].
           int,           // order (>=2)
           int,           // cv count
@@ -243,7 +243,7 @@ bool ON_ClampKnotVector(
 
 ON_DECL
 bool ON_MakeKnotVectorPeriodic(
-          // Sets inital and final order-2 knots to values
+          // Sets initial and final order-2 knots to values
           // that make the knot vector periodic
           int,           // order (>=2)
           int,           // cv count

--- a/opennurbs_layer.cpp
+++ b/opennurbs_layer.cpp
@@ -1276,7 +1276,7 @@ void ON__LayerExtensions::DeleteViewportSettings(
     {
       delete ud;
       // Set bit 0x01 of ON_Layer::m_extension_bits to prevent
-      // ON_Layer visibilty and color queries from wasting
+      // ON_Layer visibility and color queries from wasting
       // time looking for userdata.
       SetExtensionBit( const_cast<unsigned char*>(layer_m_extension_bits), 0x01 );
     }
@@ -1296,7 +1296,7 @@ void ON__LayerExtensions::DeleteViewportSettings(
       {
         delete ud;
         // Set bit 0x01 of ON_Layer::m_extension_bits to prevent
-        // ON_Layer visibilty and color queries from wasting
+        // ON_Layer visibility and color queries from wasting
         // time looking for userdata.
         SetExtensionBit( const_cast<unsigned char*>(layer_m_extension_bits), 0x01 );
       }
@@ -1530,7 +1530,7 @@ void ON_Layer::SetPerViewportPersistentVisibility( ON_UUID viewport_id, bool bVi
   if ( ON_UuidIsNotNil(viewport_id) )
   {
     bool bCreate = false; // This "false" is correct because the per viewport visibility
-                          // setting needs to be in existance for this call to make any
+                          // setting needs to be in existence for this call to make any
                           // sense in the first place.
     ON__LayerPerViewSettings* vp_settings = ON__LayerExtensions::ViewportSettings( *this, &m_extension_bits, viewport_id, bCreate );
     if (vp_settings )
@@ -1555,7 +1555,7 @@ void ON_Layer::UnsetPerViewportPersistentVisibility( ON_UUID viewport_id )
   else
   {
     bool bCreate = false; // This "false" is correct because the per viewport visibility
-                          // setting needs to be in existance for this call to make any
+                          // setting needs to be in existence for this call to make any
                           // sense in the first place.
     ON__LayerPerViewSettings* vp_settings = ON__LayerExtensions::ViewportSettings( *this, &m_extension_bits, viewport_id, bCreate );
     if (vp_settings )

--- a/opennurbs_layer.h
+++ b/opennurbs_layer.h
@@ -365,7 +365,7 @@ public:
   /*
   Description:
     The persistent visbility setting is used for layers whose
-    visibilty can be changed by a "parent" object. A common case
+    visibility can be changed by a "parent" object. A common case
     is when a layer is a child layer (ON_Layer.m_parent_id is
     not nil). In this case, when a parent layer is turned off,
     then child layers are also turned off. The persistent
@@ -407,7 +407,7 @@ public:
   /*
   Description:
     Remove any explicit persistent visibility setting from this
-    layer. When persistent visibility is not explictly set,
+    layer. When persistent visibility is not explicitly set,
     the value of ON_Layer::IsVisible() is used.
   Remarks:
     See ON_Layer::PersistentVisibility for a detailed description
@@ -577,7 +577,7 @@ public:
 
   /*
   Description:
-    Remove any explicity persistent locking settings from this
+    Remove any explicitly persistent locking settings from this
     layer.
   Remarks:
     See ON_Layer::PersistentLocking for a detailed description of
@@ -737,7 +737,7 @@ private:
   //
   // m_extension_bits & 0x01: 
   //   The value of ( m_extension_bits & 0x01) is used to speed
-  //   common per viewport visiblity and color queries.
+  //   common per viewport visibility and color queries.
   //     0x00 = there may be per viewport settings on this layer.
   //     0x01 = there are no per viewport settings on this layer.
   //

--- a/opennurbs_light.h
+++ b/opennurbs_light.h
@@ -176,7 +176,7 @@ public:
 
   //////////
   // The spot exponent varies from 0.0 to 128.0 and provides
-  // an exponential interface for controling the focus or 
+  // an exponential interface for controlling the focus or 
   // concentration of a spotlight (like the 
   // OpenGL GL_SPOT_EXPONENT parameter).  The spot exponent
   // and hot spot parameters are linked; changing one will
@@ -188,7 +188,7 @@ public:
 
   //////////
   // The hot spot setting runs from 0.0 to 1.0 and is used to
-  // provides a linear interface for controling the focus or 
+  // provides a linear interface for controlling the focus or 
   // concentration of a spotlight.
   // A hot spot setting of 0.0 corresponds to a spot exponent of 128.
   // A hot spot setting of 1.0 corresponds to a spot exponent of 0.0.

--- a/opennurbs_line.cpp
+++ b/opennurbs_line.cpp
@@ -583,7 +583,7 @@ ON_Triangle::ON_Triangle(const ON_3dPoint & a, const ON_3dPoint & b, const ON_3d
 
 ON_Triangle::ON_Triangle(double x)
 {
-	// Note this constructor overload is usefull so that ON_Triangle(0) doesn't
+	// Note this constructor overload is useful so that ON_Triangle(0) doesn't
 	// get interpreted as ON_Triangle(nullptr)
 	ON_3dPoint p(x, x, x);
 	m_V[0] = m_V[1] = m_V[2] = p;
@@ -703,7 +703,7 @@ ON_Line ON_Triangle::Edge(int i) const
 
 ON_3dVector ON_Triangle::Normal() const
 {
-	int i0 = 0; // base vetex for computation s/b opposite longest side
+	int i0 = 0; // base vertex for computation s/b opposite longest side
 									 // too minimize roundoff 
 									 // ( see Kahan https://people.eecs.berkeley.edu/~wkahan/MathH110/Cross.pdf).
 	double max_len = -1;

--- a/opennurbs_line.h
+++ b/opennurbs_line.h
@@ -117,7 +117,7 @@ public:
   Description:
     Get a plane that contains the line.
   Parameters:
-    plane - [out] a plane that contains the line.  The orgin
+    plane - [out] a plane that contains the line.  The origin
        of the plane is at the start of the line.  The distance
        from the end of the line to the plane is <= tolerance.
        If possible a plane parallel to the world xy, yz or zx
@@ -402,12 +402,12 @@ public:
 
   // Returns:
   //   Index of edge opposite to m_V[i] that is longest.
-  //   When lenghts are equal, lowest index has priority.
+  //   When lengths are equal, lowest index has priority.
   unsigned char LongestEdge() const;
 
   // Returns:
   //   Index of edge opposite to m_V[i] that is shortest.
-  //   When lenghts are equal, lowest index has priority.
+  //   When lengths are equal, lowest index has priority.
   unsigned char ShortestEdge() const;
 
 	// Returns:
@@ -432,7 +432,7 @@ public:
 
 	// Returns:
 	//   N = ( b-a) X ( c-a)
-	// where a,b,c are the verticies 
+	// where a,b,c are the vertices 
 	// See Also:
 	//   ON_Triangle UnitNormal()
 	ON_3dVector Normal() const;
@@ -440,7 +440,7 @@ public:
 	// Returns:
 	//   Normal().Unitize()
 	// Notes:
-	//		Ensure !IsDegenerate() to gaurentee that UnitNormal().Length()==1
+	//		Ensure !IsDegenerate() to guarantee that UnitNormal().Length()==1
 	//		and the result is not just a bunch of noise.  Can return zero vector 
 	//    in some degenerate cases.
 	ON_3dVector UnitNormal() const;
@@ -448,7 +448,7 @@ public:
 	// Returns:
 	//	Plane containing Triangle with normal given by UnitNormal().
 	// Notes:
-	//	Ensure !IsDegenerate() to gaurentee meaningful result
+	//	Ensure !IsDegenerate() to guarantee meaningful result
 	ON_PlaneEquation PlaneEquation() const;
 
 	/*
@@ -583,7 +583,7 @@ public:
   void Spin(unsigned char move);
 
 public:
-	ON_3dPoint m_V[3]; // verticies
+	ON_3dPoint m_V[3]; // vertices
 };
 
 /*

--- a/opennurbs_linecurve.cpp
+++ b/opennurbs_linecurve.cpp
@@ -549,7 +549,7 @@ bool ON_LineCurve::Trim( const ON_Interval& domain )
     DestroyCurveTree();
     ON_3dPoint p = PointAt( domain[0] );
     ON_3dPoint q = PointAt( domain[1] );
-		if( p.DistanceTo(q)>0){								// 2 April 2003 Greg Arden A successfull trim 
+		if( p.DistanceTo(q)>0){								// 2 April 2003 Greg Arden A successful trim 
 																					// should return an IsValid ON_LineCurve .
 			m_line.from = p;
 			m_line.to = q;

--- a/opennurbs_linestyle.h
+++ b/opennurbs_linestyle.h
@@ -62,7 +62,7 @@ public:
   ON_UUID m_viewport_id;          // identifies the ON_Viewport
                                   //   If nil, then the display material
                                   //   will be used in all viewports
-                                  //   that are not explictly referenced
+                                  //   that are not explicitly referenced
                                   //   in other ON_DisplayMaterialRefs.
 
   ON_UUID m_display_material_id;  // id used to find display attributes

--- a/opennurbs_locale.h
+++ b/opennurbs_locale.h
@@ -211,7 +211,7 @@ public:
   /*
   Returns:
     ISO 639 language code.
-    When avilable, two letter codes from ISO 639-1 are prefered.
+    When available, two letter codes from ISO 639-1 are preferred.
   Remarks:
     The InvariantCulture.LanguageCode() is "".
   See Also:
@@ -309,7 +309,7 @@ public:
 
     <language>
     ISO 639 language code.
-    When avilable, two letter codes from ISO 639-1 are prefered.
+    When available, two letter codes from ISO 639-1 are preferred.
     http://www.iso.org/iso/language_codes
 
     <Script> is optional.
@@ -343,7 +343,7 @@ public:
 
     <language>
     ISO 639 language code.
-    When avilable, two letter codes from ISO 639-1 are prefered.
+    When available, two letter codes from ISO 639-1 are preferred.
     http://www.iso.org/iso/language_codes
 
     <Script> is optional.
@@ -408,12 +408,12 @@ public:
   Returns:
     0: failed
     1: success
-       Currently The decimal piont is a period in the C-runtime 
+       Currently The decimal point is a period in the C-runtime 
        formatted printing and scanning functions.
     2: success
-       When called, the decimal piont was not a period, but
+       When called, the decimal point was not a period, but
        a call to ON_Locale::SetPeriodAsCRuntimeDecimalPoint()
-       restored the defaut behavior.
+       restored the default behavior.
   */
   static unsigned int EnforcePeriodAsCRuntimeDecimalPoint();
 
@@ -562,12 +562,12 @@ public:
 
   /*
   Description:
-    Create a locale from BCP 47 lanugage code, script code and region code.
+    Create a locale from BCP 47 language code, script code and region code.
 
   Parameters:
     language_code - [in]
       ISO 639 language code.
-      When avilable, two letter codes from ISO 639-1 are prefered.
+      When available, two letter codes from ISO 639-1 are preferred.
       http://www.iso.org/iso/language_codes
 
     script - [in]

--- a/opennurbs_lock.h
+++ b/opennurbs_lock.h
@@ -20,7 +20,7 @@
 /*
 Description:
   ON_Lock is a thread safe lock semephore. It is implemented using
-  platform specfic compare and set functions.
+  platform specific compare and set functions.
 */
 class ON_CLASS ON_Lock
 {

--- a/opennurbs_lookup.cpp
+++ b/opennurbs_lookup.cpp
@@ -200,7 +200,7 @@ void ON_SN_BLOCK::CullBlockHelper()
   // value is zero and remove them from the array.
   //
   // This is a high speed helper function.  
-  // The calling function must verfy m_purged > 0.
+  // The calling function must verify m_purged > 0.
   //
   // This function removes all m_sn[] elements
   // that have 0 == m_sn_active.
@@ -587,7 +587,7 @@ struct ON_SerialNumberMap::SN_ELEMENT* ON_SerialNumberMap::FindElementHelper(ON_
     {
       // m_sn_block0.m_sn[] needs to be sorted
       //
-      // This is a rare occurance.  It only happens
+      // This is a rare occurrence.  It only happens
       // when commands add new objects in an order that
       // is different from that in which the CRhinoObject
       // class constructor was called.  In testing,
@@ -1352,7 +1352,7 @@ ON__UINT64 ON_SerialNumberMap::GarbageCollectMoveHelper(ON_SN_BLOCK* dst,ON_SN_B
 {
   // This helper is used by GarbageCollectHelper and moves
   // as many entries as possible from src to dst.  
-  // Returns: the number of entries transfered.
+  // Returns: the number of entries transferred.
   ON__UINT32 i,j,n;
   if ( src && dst )
   {
@@ -1731,7 +1731,7 @@ struct ON_SerialNumberMap::SN_ELEMENT* ON_SerialNumberMap::AddSerialNumberAndId(
     if (IdIsEqual(&m_inactive_id, &id))
     {
       // This id was recently removed and is now being added back
-      // (which turns out to be a common occurance - go figure).
+      // (which turns out to be a common occurrence - go figure).
       // No need to check for duplicates.
       m_inactive_id = ON_nil_uuid;
     }

--- a/opennurbs_lookup.h
+++ b/opennurbs_lookup.h
@@ -359,7 +359,7 @@ private:
   ON__UINT64 m_sn_count = 0;   // total number of elements                       
   ON__UINT64 m_sn_purged = 0;  // total number of purged elements
 
-  // The blocks in m_sn_list[] are alwasy sorted, disjoint,
+  // The blocks in m_sn_list[] are always sorted, disjoint,
   // and in increasing order.  m_sn_list is used when
   // m_sn_block0.m_sn[] is not large enough.
   // The sn list is partitioned into blocks to avoid

--- a/opennurbs_material.cpp
+++ b/opennurbs_material.cpp
@@ -925,7 +925,7 @@ double ON_Material::FresnelReflectionCoefficient(
     return x; // x is
   }
 
-  return 1.0; // error occured
+  return 1.0; // error occurred
 }
 
 double  ON_Material::FresnelReflectionCoefficient(
@@ -3087,7 +3087,7 @@ int ON_TextureMapping::EvaluatePlaneMapping(
   // Apply texture coordinate transformation
   *T = m_uvw*rst;
 
-  //See docs - if m_bCapped is false, then planar is truely flat.
+  //See docs - if m_bCapped is false, then planar is truly flat.
   if (!m_bCapped)
 	  T->z = 0.0;
 
@@ -3284,7 +3284,7 @@ int ON_TextureMapping::EvaluateCylinderMapping(
     else if ( r <= 1.001 )
     {
       // The point is inside the capped cylinder.
-      // Use normal to dermine which surface to use
+      // Use normal to determine which surface to use
       // for closest point test.
 		  ON_3dVector n(m_Nxyz*N);
       if (  ( fabs(n.z) > fabs(n.x) && fabs(n.z) > fabs(n.y) ) )
@@ -3761,7 +3761,7 @@ bool ON_TextureMapping::HasMatchingTextureCoordinates(
     // values are independent of the 3d location
     // of the mesh.  The ON_TextureMapping::TYPE::srfp_mapping != m_type
     // check is used because these mappings are
-    // alwasy independent of 3d location but
+    // always independent of 3d location but
     // the transformations are often set.
     if ( ON_TextureMapping::TYPE::srfp_mapping != m_type
          && mesh_xform
@@ -5940,7 +5940,7 @@ const ON_MappingRef* ON_ObjectRenderingAttributes::MappingRef(
 
   //ALB 2013.12.03
   //Fixes http://mcneel.myjetbrains.com/youtrack/issue/RH-5730
-  //I'm sick of this bug being considered irrelavent, and since I've decided to go out of my way to
+  //I'm sick of this bug being considered irrelevant, and since I've decided to go out of my way to
   //Sort out as many mapping problems as I can, I'm fixing this one like this.
   if (m_mappings.Count() > 0)
   {
@@ -6299,7 +6299,7 @@ bool ON_ObjectRenderingAttributes::Read( ON_BinaryArchive& archive )
 
 bool ON_TextureMapping::SetSurfaceParameterMapping(void)
 {
-  // The nullptr check is wierd.
+  // The nullptr check is weird.
   // Speculation: A reference was null and somebody added this
   // as a hack to prevent a crash.
   if ( false == ON_IsNullPtr(this) )

--- a/opennurbs_material.h
+++ b/opennurbs_material.h
@@ -294,7 +294,7 @@ public:
   static ON_UUID PhysicallyBasedUserdataId(void);
 
 private:
-  // The value of m_rdk_material_id idetifies an RDK (rendering development kit)
+  // The value of m_rdk_material_id identifies an RDK (rendering development kit)
   // material. Multiple materials in a Rhino model can refer to the same
   // RDK material id.  In V5 this value is stored in user data.  In V6 it is
   // saved in the m_rdk_material_id field.
@@ -425,7 +425,7 @@ public:
                 any texture type matches.
     i0 - [in] If i0 is < 0, the search begins at
               m_textures[0], if i0 >= m_textures.Count(),
-              -1 is returnd, otherwise, the search begins
+              -1 is returned, otherwise, the search begins
               at m_textures[i0+1].
   Example:
     Iterate through all the the bitmap textures on
@@ -523,7 +523,7 @@ public:
     The m_material_channel[] array is used to provide per face rendering material support for ON_SubD and ON_Brep objects.
     ON_Mesh objects to not support per face render materials.
     The application specifies a base ON_Material for rendering the subd or brep and a way to find materials from ON_UUID values.
-    ON_Material.Id() retuns the id for any given material.
+    ON_Material.Id() returns the id for any given material.
 
     ON_BrepFace::MaterialChannelIndex() and ON_SubDFace::MaterialChannelIndex()
     specify a material channel index. If this value is 0, then the base

--- a/opennurbs_math.cpp
+++ b/opennurbs_math.cpp
@@ -168,7 +168,7 @@ bool ON_PassesNanTest()
     const double zero = 0.0;
     const double one = 1.0;
 
-    // nan != * and * != nan should alwasy be true
+    // nan != * and * != nan should always be true
     const bool b_NE_test
       = nan1 != nan1
       && nan1 != nan2
@@ -809,7 +809,7 @@ bool ON_EvTangent(
 
   if (d1 == 0.0) 
   {
-    // Use L'hopital's rule to show that if the unit tanget
+    // Use L'hopital's rule to show that if the unit tangent
     // exists and the 1rst derivative is zero and the 2nd derivative is
     // nonzero, then the unit tangent is equal to +/-the unitized 
     // 2nd derivative.  The sign is equal to the sign of D1(s) o D2(s)
@@ -852,7 +852,7 @@ ON_EvCurvature(
 
   if (d1 == 0.0) 
   {
-    // Use L'hopital's rule to show that if the unit tanget
+    // Use L'hopital's rule to show that if the unit tangent
     // exists and the 1rst derivative is zero and the 2nd derivative is
     // nonzero, then the unit tangent is equal to +/-the unitized 
     // 2nd derivative.  The sign is equal to the sign of D1(s) o D2(s)
@@ -1995,7 +1995,7 @@ ON_SolveQuadraticEquation(
  *   is numerical noise and is assumed to be zero.
  *
  *   If it is really important to have the best possible answer,
- *   you sould probably tune up the returned roots using
+ *   you should probably tune up the returned roots using
  *   Brent's algorithm.
  *
  * REFERENCE:
@@ -2229,7 +2229,7 @@ COMMENTS:
   The computation is performed in such a way that the output
   "X" pointer can be equal to the input "d" pointer; i.e., if the
   d array will not be used after the call to ON_SolveTriDiagonal(), then
-  it is not necessary to allocate seperate space for X and d.
+  it is not necessary to allocate separate space for X and d.
 EXAMPLE:
 REFERENCE:
   NRC, section 2.6
@@ -2566,7 +2566,7 @@ double ON_SolveNxN(bool bFullPivot, bool bNormalize, int n, double* M[], double 
     // The Xdex_buffer[] hoo haa is here to avoid an potentially time
     // consuming call to heap services when the matrix is small.
     // When n > 64 the numerical portion of the computation is 
-    // long enough that the time to call onmalloc() is negligable.
+    // long enough that the time to call onmalloc() is negligible.
     // (When n > 10-ish, this calculation is likely to return junk
     // unless you have a special case matrix, in which case this
     // function will be much slower than one that is designed to
@@ -4928,7 +4928,7 @@ bool ON_Sym3x3EigenSolver(double A, double B, double C,
 		&ee2, EE2,
 		&ee3, EE3);
 
-	/* Step 3. Apply rotation to express results in orignal coordinate system  */
+	/* Step 3. Apply rotation to express results in original coordinate system  */
 	E1.Set(cos_phi*EE1.x + sin_phi * EE1.z, EE1.y, -sin_phi * EE1.x + cos_phi * EE1.z);
 	E2.Set(cos_phi*EE2.x + sin_phi * EE2.z, EE2.y, -sin_phi * EE2.x + cos_phi * EE2.z);
 	E3.Set(cos_phi*EE3.x + sin_phi * EE3.z, EE3.y, -sin_phi * EE3.x + cos_phi * EE3.z);
@@ -5012,7 +5012,7 @@ bool ON_SymTriDiag3x3EigenSolver(double A, double B, double C,
 
 /*
 Description:
-	QL Algorithm with implict shifts, to determine the eigenvalues and eigenvectors of a
+	QL Algorithm with implicit shifts, to determine the eigenvalues and eigenvectors of a
 	symmetric, tridiagonal matrix.
 
 Parametrers:
@@ -5022,7 +5022,7 @@ Parametrers:
 								with e[n-1] not used, but must be allocated.
 								on output e is unpredictable.
 n - [in]      matrix is n by n
-pV - [out]		If not nullptr the it should be an n by n matix.
+pV - [out]		If not nullptr the it should be an n by n matrix.
 							The kth column will be a normalized eigenvector of d[k]
 */
 bool ON_TriDiagonalQLImplicit(double* d, double* e, int n, ON_Matrix* pV)

--- a/opennurbs_math.h
+++ b/opennurbs_math.h
@@ -174,7 +174,7 @@ public:
     periodic - [in] if not nullptr, then this is an array of 
                 parameter_count bools where b[i] is true if
                 the i-th parameter is periodic.  Valid 
-                increasing finite domains must be specificed
+                increasing finite domains must be specified
                 when this parameter is not nullptr.
   */
   ON_Evaluator( 
@@ -237,7 +237,7 @@ public:
   Description:
     OPTIONAL ability to evaluate the hessian in the case when 
     m_value_count is one.  If your function has more that
-    one value or it is not feasable to evaluate the hessian,
+    one value or it is not feasible to evaluate the hessian,
     then do not override this function.  The default implementation
     returns -1.
   Parameters:
@@ -826,7 +826,7 @@ bool ON_PointsAreCoincident(
 /*
 Description
   See ON_PointsAreCoincident() for a description of when opennurbs
-  considers two points to be conincident.
+  considers two points to be coincident.
 Parameters:
   dim - [in]
     >= 1
@@ -932,9 +932,9 @@ Returns:
   allocated on the heap by calling onmalloc().  If input is not valid,
   nullptr is returned.
 Remarks:
-  The ids are invarient under invertable transformations.  
+  The ids are invariant under invertable transformations.  
   Specifically, if one point point set is a rotation of another, then
-  the assiged ids will be the same.
+  the assigned ids will be the same.
 */
 ON_DECL
 unsigned int* ON_GetPointLocationIds(
@@ -1011,7 +1011,7 @@ int ON_SolveQuadraticEquation( // solve a*X^2 + b*X + c = 0
 Description:
   Solve the cubic equation a*X^3 + b*X^2 + c*X + d = 0.
 Inputs:
-  a,b,c,d, polynomial coeficients ( if a==b==c== 0) then failure is returned
+  a,b,c,d, polynomial coefficients ( if a==b==c== 0) then failure is returned
 Returns: 
   number of real roots stored with multiplicity.
   specifically
@@ -1068,8 +1068,8 @@ int ON_Solve2x2(
 //          x*col0[2] + y*col1[2] = d0
 //
 // Parameters:
-//   col0 - [in] coefficents for "x" unknown
-//   col1 - [in] coefficents for "y" unknown
+//   col0 - [in] coefficients for "x" unknown
+//   col1 - [in] coefficients for "y" unknown
 //   d0 - [in] constants
 //   d1 - [in]
 //   d2 - [in]
@@ -1228,13 +1228,13 @@ Description:
   solution to M*X = B where M is a n x n matrix,
   B is a known n-dimensional vector and X is
   an unknown.
-Paramters:
+Parameters:
   bFullPivot - [in] if true, full pivoting is used,
     otherwise partial pivoting is used.  In rare
     cases full pivoting can produce a more accurate
     answer and never produces a less accurate answer.
     However full pivoting is slower.  If speed is an
-    issue, then experiement with bFullPivot=false
+    issue, then experiment with bFullPivot=false
     and see if it makes a difference.  Otherwise,
     set it to true.
   bNormalize - [in]
@@ -1265,7 +1265,7 @@ Returns:
   the discussion below. If pr <= 1e-15, then
   M was nearly degenerate and the solution should be
   used with caution.  If an accurate solution is
-  critcial, then check the solution anytime pr <= 1e-10
+  critical, then check the solution anytime pr <= 1e-10
   In general, the difference between M*X and B will be
   reasonably small.  However, when the pr is small
   there tend to be vector E, substantually different
@@ -1417,7 +1417,7 @@ bool ON_EvTangent(
         ON_3dVector&        // Unit tangent returned here
         );
 
-// returns false if first derivtive is zero
+// returns false if first derivative is zero
 ON_DECL
 bool ON_EvCurvature(
         const ON_3dVector&, // first derivative
@@ -1505,7 +1505,7 @@ ON_3dVector ON_NormalCurvature(
 
 /*
 Description:
-  Determing if two curvatrues are different enough
+  Determine if two curvatrues are different enough
   to qualify as a curvature discontinuity.
 Parameters:
   Km - [in]
@@ -1516,7 +1516,7 @@ Parameters:
     points and tangents and consider to curve to be G1 at the
     point in question.
   cos_angle_tolerance - [in]
-    If the inut value of cos_angle_tolerance >= -1.0
+    If the input value of cos_angle_tolerance >= -1.0
     and cos_angle_tolerance <= 1.0 and
     Km o Kp < cos_angle_tolerance*|Km|*|Kp|, then
     true is returned.  Otherwise it is assumed Km and Kp
@@ -1527,7 +1527,7 @@ Parameters:
   curvature_tolerance - [in]
     If |Kp-Km| <= curvature_tolerance,
     then false is returned, otherwise other tests are used
-    to determing continuity.
+    to determine continuity.
   zero_curvature - [in] (ignored if < 2^-110 = 7.7037197787136e-34)
     If |K| <= zero_curvature, then K is treated as zero.
     When in doubt, use ON_ZERO_CURVATURE_TOLERANCE.
@@ -1746,7 +1746,7 @@ int ON_Intersect(
                  const ON_Plane&, const ON_Sphere&, ON_Circle&
                   );
 
-// Intersects an infinte line and sphere and returns 
+// Intersects an infinite line and sphere and returns 
 // 0 = no intersections, 
 // 1 = one intersection, 
 // 2 = 2 intersections
@@ -1765,7 +1765,7 @@ int ON_Intersect(
         );
 
 
-// Intersects an infinte line and cylinder and returns 
+// Intersects an infinite line and cylinder and returns 
 // 0 = no intersections, 
 // 1 = one intersection, 
 // 2 = 2 intersections
@@ -1789,7 +1789,7 @@ int ON_Intersect(
       );
 
 // Description:
-//   Intersect an infinte line and circle.
+//   Intersect an infinite line and circle.
 // Parameters:
 //   line - [in]
 //   circle - [in]
@@ -1815,7 +1815,7 @@ int ON_Intersect(
 
 
 // Description:
-//   Intersect a infinte line and arc.
+//   Intersect a infinite line and arc.
 // Parameters:
 //   line - [in]
 //   arc - [in]
@@ -2154,8 +2154,8 @@ Parameters:
     estimate of the validity of the solution, then inspect
     the returned values.  max_pivot should around 1, 
     min_pivot should be > 1e-4 or so, and zero_pivot should
-    be < 1e-10 or so.  If the returned pivots don't satisify
-    these condtions, then exercise caution when using the
+    be < 1e-10 or so.  If the returned pivots don't satisfy
+    these conditions, then exercise caution when using the
     returned solution.
 Returns:
   True if a there is an ellipse, parabola or hyperbola through the  
@@ -2233,7 +2233,7 @@ Remarks:
   Here is the way to evaluate a point on the ellipse:
 
           
-          double t = ellipse paramter in radians;
+          double t = ellipse parameter in radians;
           double x = a*cos(t);
           double y = b*sin(t);
           ON_2dPoint ellipse_point;
@@ -2253,7 +2253,7 @@ ON_DECL bool ON_GetEllipseConicEquation(
       );
 
 /*
-Descripton:
+Description:
   Return the length of a 2d vector (x,y)
 Returns:
  sqrt(x^2 + y^2) calculated in as precisely and safely as possible.
@@ -2261,7 +2261,7 @@ Returns:
 ON_DECL double ON_Length2d( double x, double y );
 
 /*
-Descripton:
+Description:
   Return the length of a 3d vector (x,y,z)
 Returns:
  sqrt(x^2 + y^2 + z^2) calculated in as precisely and safely as possible.

--- a/opennurbs_matrix.cpp
+++ b/opennurbs_matrix.cpp
@@ -1596,7 +1596,7 @@ unsigned int ON_RowReduce(
       }
     }
 
-    // swap columns M[jj] and M[rank] to maximum coefficeint is in M[rank][rank]
+    // swap columns M[jj] and M[rank] to maximum coefficient is in M[rank][rank]
     xx = -a[jj];
     a[jj] = a[rank];
     //a[rank] = -xx; // DEBUG
@@ -1837,7 +1837,7 @@ unsigned int ON_GetEigenvectors(
 
     if (bLastTry)
     {
-      // For an explaination, see the code below where bLastTry is set to true.
+      // For an explanation, see the code below where bLastTry is set to true.
       break;
     }
 

--- a/opennurbs_matrix.h
+++ b/opennurbs_matrix.h
@@ -372,7 +372,7 @@ public:
   //       in under determined systems of equations.
   //   pt_dim - [in] dimension of points
   //   Bsize - [in] (>=m_row_count) number of points in B[].  The points
-  //       correspoinding to indices m_row_count, ..., (Bsize-1)
+  //       corresponding to indices m_row_count, ..., (Bsize-1)
   //       are tested to make sure they are "zero".
   //   Bpt_stride - [in] stride between B points (>=pt_dim)
   //   Bpt - [in/out] array of m_row_count*Bpt_stride values.
@@ -555,7 +555,7 @@ Parameters:
   eigenvectors - [out]
     eigenvectors[0,...,eigendim-1][0,...,N-1]
     a basis for the lambda eigenspace.  The eigenvectors are generally
-    neither normalized nor orthoganal. 
+    neither normalized nor orthogonal. 
 
   eigenprecision - [out]
     eigenprecision[i] = maximum value of fabs(lambda*E[j] = E[j])/length(E) 0 <= j < N,

--- a/opennurbs_md5.h
+++ b/opennurbs_md5.h
@@ -201,7 +201,7 @@ Remarks:
   The MD5 hash algorithm is not suitable for cryptographic or security applications.
   The ON_MD5 class does not "wipe" intermediate results.
   
-  The probability of two different randomly selected seqences of N bytes to have the
+  The probability of two different randomly selected sequences of N bytes to have the
   same value MD5 hash depends on N, but it is roughly 2^-64 ~ 10^-19.
 
   MD5 hash values are 16 bytes. SHA-1 hash values are 20 bytes. If you need a hash
@@ -272,7 +272,7 @@ public:
     Put another way, you may call Update() zero or more times passing in N1 bytes, 
     call Digest() to get the MD5 hash of those N1 bytes, make zero or more additional
     calls to Update() passing in N2 additional bytes, call digest to get the MD5 hash
-    of the seqence of (N1 + N2) bytes, and so on.
+    of the sequence of (N1 + N2) bytes, and so on.
   */
   ON_MD5_Hash Hash() const;
 
@@ -313,7 +313,7 @@ private:
   ON__UINT32 m_bit_count[2];   // number of bits (lo, hi)
   ON__UINT32 m_state[4];       // current state
   
-  // chached MD5 hash - valid if 2 = (2 & m_status_bits)
+  // cached MD5 hash - valid if 2 = (2 & m_status_bits)
   mutable ON_MD5_Hash m_md5_hash;
 };
 

--- a/opennurbs_memory.h
+++ b/opennurbs_memory.h
@@ -64,7 +64,7 @@ class ON_CLASS ON_MemoryAllocationTracking
 {
 public:
   /*
-  Descrption:
+  Description:
     Windows Debug Builds:
       The constructor saves the current state of memory allocation tracking
       and then enables/disables memory allocation tracking.
@@ -76,9 +76,9 @@ public:
   );
 
   /*
-  Descrption:
+  Description:
     Windows Debug Builds:
-      The desctructor restores the saved state of memory allocation tracking.
+      The destructor restores the saved state of memory allocation tracking.
     Otherwise:
       Does nothting.
   */

--- a/opennurbs_memory_util.cpp
+++ b/opennurbs_memory_util.cpp
@@ -25,7 +25,7 @@
 #endif
 
 // Memory utilities used by OpenNURBS.  If you are using
-// custom memory managment, NOTHING in this file needs to
+// custom memory management, NOTHING in this file needs to
 // be changed.
 
 

--- a/opennurbs_mesh.cpp
+++ b/opennurbs_mesh.cpp
@@ -110,7 +110,7 @@ public:
   //
   // Whenever there is a question about which values are valid,
   // it is assumed the m_V array is valid and the double precision
-  // informtion should be destroyed.
+  // information should be destroyed.
   int m_fcount = 0;  // single precision vertex count
   int m_dcount = 0;  // double precision vertex count
   ON__UINT32 m_fCRC = 0; // crc of float vertex array
@@ -1223,11 +1223,11 @@ bool ON_Mesh::IsValid( ON_TextLog* text_logx ) const
     const ON_3fPoint* fV = m_V.Array();
     for ( fi = 0; fi < facet_count; fi++ ) 
     {
-      // This test is considered relatively harsh for float precision meshes with nearly degnerate faces
+      // This test is considered relatively harsh for float precision meshes with nearly degenerate faces
       // after they are transformed by a transform with a reasonable sized translation 
       // component, as in https://mcneel.myjetbrains.com/youtrack/issue/RH-10177.
       // However, removing this creates unreasonable pressure on double precision meshes, because, after being 
-      // trasformed to double precision, a wrongly valid single-precision-collapsed-edge mesh makes an
+      // transformed to double precision, a wrongly valid single-precision-collapsed-edge mesh makes an
       // invalid double-precision mesh altogether. This cannot be tolerated.
       // The goal should be to have invalid single-precision-only meshes be treated by MeshRepair when created.
       // See https://mcneel.myjetbrains.com/youtrack/issue/RH-54563 and
@@ -3027,7 +3027,7 @@ bool ON_Mesh::SwapCoordinates(
 
 void ON_Mesh::SetClosed(int b)
 {
-  // 6 Novermber 2003 Dale Lear - let expert user set m_mesh_is_closed
+  // 6 November 2003 Dale Lear - let expert user set m_mesh_is_closed
   char mesh_is_closed = 0;
   switch(b)
   {
@@ -5351,7 +5351,7 @@ void ON_Mesh::Append( int mesh_count, const ON_Mesh* const* meshes )
         {
           if (this_mesh_mp_hash != mp_hash)
           {
-            // variable mesh paramters - means output gets none.
+            // variable mesh parameters - means output gets none.
             bSetMeshParameters = false;
           }
         }
@@ -6587,7 +6587,7 @@ ON_SHA1_Hash ON_MeshParameters::GeometrySettingsHash(bool bIgnoreSubDParameters)
 
     // Do not include m_min_tolerance as a geometry setting.
     // It is a runtime lower bound clamp.
-    // If it is included here, Rhino will remesh everytime model tolerance changes.
+    // If it is included here, Rhino will remesh every time model tolerance changes.
     sha1.AccumulateDouble(ON_MeshParameters_SHA1Double(m_min_edge_length,0.0));
     sha1.AccumulateDouble(ON_MeshParameters_SHA1Double(m_max_edge_length,0.0));
     sha1.AccumulateDouble(ON_MeshParameters_SHA1Double(m_grid_aspect_ratio,0.0));
@@ -6608,7 +6608,7 @@ ON_SHA1_Hash ON_MeshParameters::GeometrySettingsHash(bool bIgnoreSubDParameters)
     {
       // The Pangolin parameters and any other, parameters we add in the future,
       // contribute to the SHA1 only when they differ from default values.
-      // This keeps old SHA-1 values correct and prevents remeshing when openning
+      // This keeps old SHA-1 values correct and prevents remeshing when opening
       // old files.
       sha1.AccumulateId(m_mesher_id);
 
@@ -6820,7 +6820,7 @@ static bool Internal_MeshParametersRead_UpdateSubDParameters(
   const size_t mp_count = sizeof(mp) / sizeof(mp[0]);
   for (size_t mp_dex = 0; mp_dex < mp_count; ++mp_dex)
   {
-    // If the only geometry setting differnce bewteen a built-in type and archive_mp
+    // If the only geometry setting difference between a built-in type and archive_mp
     // is the subd meshing parameters, update archive_mp to use the built-in's subd 
     // meshing parameters.
     const ON_SubDDisplayParameters mp_subdp = mp[mp_dex].SubDDisplayParameters();
@@ -7237,7 +7237,7 @@ struct EDGEINFO
             // 6 = edge would be a boundary if mesh were exploded
             // 7 = quad would not be convex
             // 8 = if the edge were removed, the quad would not pass the min_diagonal_length_ratio test (not "square" enough)
-            // 16 = tha diagnoal is too short to remove in the first pass that makes the "obvious" quads.
+            // 16 = the diagnoal is too short to remove in the first pass that makes the "obvious" quads.
   double length;
 };
 
@@ -7438,7 +7438,7 @@ bool ON_Mesh::ConvertTrianglesToQuads(
     {
       // It is CRITICAL that the length compare use >=.
       // Otherwise tesselations of equailateral triangles
-      // will not work right in this fuction.
+      // will not work right in this function.
       fei = top.m_topf[ei.fi[0]].m_topei;
       if ((i != fei[0] && EI[fei[0]].length >= ei.length)
         || (i != fei[1] && EI[fei[1]].length >= ei.length)
@@ -7457,7 +7457,7 @@ bool ON_Mesh::ConvertTrianglesToQuads(
 
       // It is CRITICAL that the length compare use >=.
       // Otherwise tesselations of equailateral triangles
-      // will not work right in this fuction.
+      // will not work right in this function.
       fei = top.m_topf[ei.fi[1]].m_topei;
       if ((i != fei[0] && EI[fei[0]].length >= ei.length)
         || (i != fei[1] && EI[fei[1]].length >= ei.length)
@@ -9625,7 +9625,7 @@ bool ON_MeshTopology::Create()
 
   while ( 0 == b32IsValid || -1 == b32IsValid ) 
   {
-    // while() is for flow control - this is a while() {... break;} statment.
+    // while() is for flow control - this is a while() {... break;} statement.
     Destroy();
     b32IsValid = 0;
 
@@ -12269,7 +12269,7 @@ void ON_Mesh::UpdateDoublePrecisionVertices()
     // a subset of the float precision vertices
     // have been modified.  So, attempt to
     // keep the precision on double vertices
-    // that alread agree with the float vertices
+    // that already agree with the float vertices
     // in float precision.
     ON_3fPoint P;
     while (dV < dVend)
@@ -15939,7 +15939,7 @@ unsigned int ON_Mesh::MergeFaceSets(
       ngon_fi.Append(fi);
     }
 
-    // grow ngon by jumping accross edges in ci_list[]
+    // grow ngon by jumping across edges in ci_list[]
     Internal_GrowNgon(
       top, emarks, fmarks,
       e_list_mark | fmark, // etest_mask,

--- a/opennurbs_mesh.h
+++ b/opennurbs_mesh.h
@@ -449,13 +449,13 @@ public:
 
     ///<summary>
     /// These parameters are being used to generate a quad mesh approximations of an ON_SubD.
-    /// Low level meshing code copies input paramters and specifies this context when appropriate.
+    /// Low level meshing code copies input parameters and specifies this context when appropriate.
     ///</summary>
     SubDToMesh = 1,
 
     ///<summary>
     /// These parameters are being used to generate NURBS surface approximations of an ON_SubD.
-    /// Low level conversion to NURB code copies input paramters and specifies this context when appropriate.
+    /// Low level conversion to NURB code copies input parameters and specifies this context when appropriate.
     ///</summary>
     SubDToNURBS = 2
   };
@@ -467,7 +467,7 @@ public:
     occasional looks at the context. Typically it is set in a local
     copy and no user of the top level ON_SubD SDK needs to be concerned
     about the context setting. 
-    This setting is not saved in 3dm archives and is ingnored by all compare functions.
+    This setting is not saved in 3dm archives and is ignored by all compare functions.
   */
   ON_SubDDisplayParameters::Context ContextForExperts() const;
 
@@ -686,30 +686,30 @@ public:
 
   /*
   Description:
-    Mesh creationg parameters to create the default render mesh.
+    Mesh creation parameters to create the default render mesh.
   */
   static 
   const ON_MeshParameters DefaultMesh;
 
   /*
   Description:
-    Mesh creationg parameters to create the a render mesh
-    when meshing speed is prefered over mesh quality.
+    Mesh creation parameters to create the a render mesh
+    when meshing speed is preferred over mesh quality.
   */
   static 
   const ON_MeshParameters FastRenderMesh;
 
   /*
   Description:
-    Mesh creationg parameters to create the a render mesh
-    when mesh quality is prefered over meshing speed.
+    Mesh creation parameters to create the a render mesh
+    when mesh quality is preferred over meshing speed.
   */
   static 
   const ON_MeshParameters QualityRenderMesh;
 
   /*
   Description:
-    Mesh creationg parameters to create the default analysis mesh.
+    Mesh creation parameters to create the default analysis mesh.
   */
   static 
   const ON_MeshParameters DefaultAnalysisMesh;
@@ -750,7 +750,7 @@ public:
     Otherwise, ON_DBL_QNAN is returned.
   Remarks:
     The values of m_bDoublePrecision, m_bClosedObjectPostProcess, and m_texture_range can be arbitrary
-    because they do not determine geometry of the resulting mesh and are typically ingored. 
+    because they do not determine geometry of the resulting mesh and are typically ignored. 
     You must compare these properties if they matter in your particular context.
   */
   double MeshDensity() const;
@@ -765,7 +765,7 @@ public:
     Otherwise, ON_DBL_QNAN is returned.
   Remarks:
     The values of m_bDoublePrecision, m_bClosedObjectPostProcess, and m_texture_range can be arbitrary
-    because they do not determine geometry of the resulting mesh and are typically ingored.
+    because they do not determine geometry of the resulting mesh and are typically ignored.
     You must compare these properties if they matter in your particular context.
   */
   double MeshDensity(bool bIgnoreSubDParameters ) const;
@@ -839,7 +839,7 @@ public:
 
   /*
   Description:
-    Tool for provding a simple "slider" interface.
+    Tool for providing a simple "slider" interface.
   Parameters:
     normalized_mesh_density - [in] 0.0 <= normalized_mesh_density <= 1.0
       0 quickly creates extremely coarse meshes.
@@ -896,7 +896,7 @@ public:
   Returns:
     A hash of values that control mesh geometry.
   Remarks:
-    Teh has intentionally ignores 
+    The hash intentionally ignores 
     m_bCustomSettings, m_bCustomSettingsEnabled, m_bComputeCurvature, 
     m_bDoublePrecision, m_bClosedObjectPostProcess, m_texture_range.
     If you need to include those values, call ContentHash().
@@ -910,7 +910,7 @@ public:
   Returns:
     A hash of values that control mesh geometry.
   Remarks:
-    Teh has intentionally ignores
+    The hash intentionally ignores
     m_bCustomSettings, m_bCustomSettingsEnabled, m_bComputeCurvature,
     m_bDoublePrecision, m_bClosedObjectPostProcess, m_texture_range.
     If you need to include those values, call ContentHash().
@@ -968,7 +968,7 @@ public:
   // the model or application default mesh creation parameters.
   //
   // When CustomSettings() is true, it indicates these mesh 
-  // creation parameters are explictily set for the object
+  // creation parameters are explicitly set for the object
   // and context in question and should override the model
   // or application defaults.
   //
@@ -1079,7 +1079,7 @@ public:
   //   entire surface domain.  For meshes of trimmed
   //   surfaces when the active area is a small subset of
   //   the entire surface, there will be large regions of
-  //   unsued texture space in [0,1]x[0,1].  When the 3d region
+  //   unused texture space in [0,1]x[0,1].  When the 3d region
   //   being meshed is far from being sqaure-ish, there will be
   //   a substantual amount of distortion mapping [0,1]x[0,1]
   //   texture space to the 3d mesh.
@@ -1365,7 +1365,7 @@ public:
   
   double m_infinity; // curvature values >= this are considered infinite
                      // and not used to compute the m_average or m_adev
-  int    m_count_infinite; // number of "infinte" values
+  int    m_count_infinite; // number of "infinite" values
   int    m_count;    // count of "finite" values
   double m_mode;     // mode of "finite" values
   double m_average;  // average of "finite" values
@@ -2409,7 +2409,7 @@ Returns:
     mesh_F - [in]
       nullptr of mesh faces - required for boundary checks
     workspace_buffer - [in]
-      If you are passing in mesh_F and you are testing testing multple 
+      If you are passing in mesh_F and you are testing testing multiple 
       ngons, then consider providing a workspace_buffer that will be automatically
       reused for successive ngons.
   Returns:
@@ -2507,10 +2507,10 @@ private:
   void* m_active;   // active Vcount+Fcount >= 16
 
 private:
-  // prohibit copy construction. No implentation.
+  // prohibit copy construction. No implementation.
   ON_MeshNgonAllocator(const ON_MeshNgonAllocator&) = delete;
 
-  // prohibit operator=. No implentation.
+  // prohibit operator=. No implementation.
   ON_MeshNgonAllocator& operator=(const ON_MeshNgonAllocator&) = delete;
 };
 
@@ -2577,7 +2577,7 @@ public:
   Description:
     Sort the face_sides[] using the compare function 
     ON_MeshFaceSide::CompareVertexIndex().
-  Paramters:
+  Parameters:
     face_sides - [in/out]
       array to sort
     face_sides_count - [in]
@@ -2594,7 +2594,7 @@ public:
   Description:
     Sort the face_sides[] using the compare function 
     ON_MeshFaceSide::CompareFaceIndex().
-  Paramters:
+  Parameters:
     face_sides - [in/out]
       array to sort
     face_sides_count - [in]
@@ -2639,7 +2639,7 @@ public:
     face_side_list - [out]
       - If the input value of face_side_list is not null, then face_side_list[] 
         must be long enough to hold the returned face_side_list list.  
-        The maximum posssible length is 4*mesh_face_list.FaceCount().
+        The maximum possible length is 4*mesh_face_list.FaceCount().
       - If the input falue of face_side_list is null, memory will be allocated
         using onmalloc() and the caller is responsible for calling onfree() at
         an appropriate time.
@@ -2888,7 +2888,7 @@ public:
 
   //////////
   // m_topv_map[] has length m_mesh.VertexCount() and 
-  // m_topv[m_topv_map[vi]] is the topological mesh vertex that is assocated
+  // m_topv[m_topv_map[vi]] is the topological mesh vertex that is associated
   // the with the mesh vertex m_mesh.m_V[vi].
   ON_SimpleArray<int> m_topv_map;
 
@@ -3333,7 +3333,7 @@ public:
       Pass true unless you have a good reason for keeping
       empty ngons.
   Returns:
-    True: succesful
+    True: successful
     False: failure - no changes.
   */
   bool DeleteComponents(
@@ -3375,7 +3375,7 @@ Parameters:
     removal of vertices, faces, etc.
     This needs to be allocated to be at least m_F.Count() long.
 Returns:
-  True: succesful
+  True: successful
   False: failure - no changes.
 */
   bool DeleteComponents(
@@ -3889,7 +3889,7 @@ Returns:
     Setting this value correctly after a mesh is constructed 
     can save time when IsClosed() is called.
     This function sets the private member variable m_is_closed.
-  Paramters:
+  Parameters:
     closed - [in]
       0: The mesh is not closed.  There is at least one face with an 
          edge that is geometrically distinct (as an unoriented line segment)
@@ -3952,7 +3952,7 @@ Returns:
     can save time when IsSolid() is called.
     This function sets the private member variable m_is_solid.
     If solid is nonzero, it will set m_is_closed to 1.
-  Paramters:
+  Parameters:
     solid - [in]
       0: The mesh is not an oriented manifold solid mesh. Either
          the mesh is not closed, not manifold, or the faces are
@@ -3992,7 +3992,7 @@ Returns:
   /*
   Description:
     Determine if a point is inside a solid brep.
-  Paramters:
+  Parameters:
     test_point - [in]
     tolerance - [in] >= 0.0
       3d distance tolerance used for ray-mesh intersection
@@ -4029,12 +4029,12 @@ Returns:
       array of vertex indices
     bNoDuplicates - [in]
       If true, then only one edges[] is added for each edge,
-      the first vertex index will alwasy be less than the
+      the first vertex index will always be less than the
       second, and the returned elements are sorted in dictionary
       order.
       If false and an edge is shared by multiple faces, then
       there will be an edges[] element added for each face and the
-      order of the vertex indicies will indicate the orientation
+      order of the vertex indices will indicate the orientation
       of the edge with respect to the face.  No sorting is performed
       in this case.
     edges - [out]
@@ -4059,7 +4059,7 @@ Returns:
     edges - [out]
       Each edges[] element is a pair of vertex indices.  There
       is at least one face in the mesh with an edge running between
-      the indicies.
+      the indices.
   Returns:
     Number of ON_2dex values appended to the edges[] array.
   */
@@ -4075,7 +4075,7 @@ Returns:
     first_vid - [in]
       Initial vertex id.  Typically 1 or 0.
     Vid - [out]
-      If not null, then Vid[] sould be an array of length VertexCount().
+      If not null, then Vid[] should be an array of length VertexCount().
       and the vertex ids will be stored in this array.  If null,
       the array will be allocated by calling onmalloc().  The returned
       array Vid[i] is the id of the vertex m_V[i].  If m_V[i] and
@@ -4111,7 +4111,7 @@ Returns:
       ON_MeshFaceSide::vi[] values.
     sides - [out]
       If the input value of sides is not null, then sides[] must be long 
-      enough to hold the returned side list.  The maximum posssible length
+      enough to hold the returned side list.  The maximum possible length
       is 4*FaceCount() for a mesh contining FaceCount() nondegenerate quads.
       If the input value of sides is null, memory will be allocated using
       onmalloc() and the caller is responsible for calling onfree() at an
@@ -4382,7 +4382,7 @@ Returns:
         facet_component_labels[] will be an array with the same size
         as ON_Mesh.m_F.Count() and facet_component_labels[i]
         is the component id m_F[i] belongs to.  The component id
-        will be 1 to the number of compoents.
+        will be 1 to the number of components.
     Returns:
       Number of components on success, 0 on failure 
   */
@@ -4520,13 +4520,13 @@ Returns:
           {
             dv[i] = ...
           }
-          // This call updates the single precison values
+          // This call updates the single precision values
           // in m_V[] and sets all the counts and CRCs that
           // are used in validity checking.
           mesh.UpdateSinglePrecisonVertices();
     
   Remarks:
-    Avoid mulitple calls to DoublePrecisionVertices().
+    Avoid multiple calls to DoublePrecisionVertices().
     It is most efficient to make one call, save a local 
     reference, and use the local reference as needed.
   */
@@ -4587,7 +4587,7 @@ Returns:
 
   /*
   Returns:
-    null - This mesh does ot have n-gon information.
+    null - This mesh does not have n-gon information.
     not null - a pointer to an array of ON_MeshNgon pointers.
       The array has length ON_Mesh::NgonCount().
   Remarks:
@@ -4601,7 +4601,7 @@ Returns:
     ngon_index - [in]
       Index of an ngon.
   Returns:
-    A pointetr to the indexed n-gon or null if the 
+    A pointer to the indexed n-gon or null if the 
     indexed ngon is null or ngon_index is out of range.
   Remarks:
     If ON_Mesh::RemoveNgon has been called, then a null
@@ -4723,7 +4723,7 @@ Returns:
       If true, also ngons that contain inner boundaries are allowed.
     faceVertexMap
       If nullptr, this will be set to a new faceVertexMap. Must be freed with onfree().
-      It is responsability of the user to call onfree() on the created object.
+      It is responsibility of the user to call onfree() on the created object.
   Returns:
     index of the new n-gon.
     -1: If input information is not valid.
@@ -4979,7 +4979,7 @@ Returns:
         need it for other reasons or you already have one.
     planar_tolerance - [in] 
       For faces to be coplanar, all the points in the
-      n-gon must be withing planar_tolerance of the plane
+      n-gon must be within planar_tolerance of the plane
       defined by the first face in the n-gon.
     minimum_ngon_vertex_count - [in]
       n-gons must have at least this many sides in order
@@ -5114,7 +5114,7 @@ Returns:
     );
 
   /*
-  Descrption:
+  Description:
     Given a group of connected coplanar faces,
     find the n-gon boundary.
   ngon_fi_count - [in]
@@ -5305,7 +5305,7 @@ The map is an array of length m_F.Count(), ngon_map[]
   // Implementation - surface parameters and packed texture 
   // information
   //
-  // If m_S.Count() == m_V.Count(), then the mesh is a tesselation
+  // If m_S.Count() == m_V.Count(), then the mesh is a tessellation
   // of a parameteric surface and m_S[j] is the surface parameter at
   // m_V[j].  Storing values in m_S[] is OPTIONAL.
   //
@@ -5371,13 +5371,13 @@ The map is an array of length m_F.Count(), ngon_map[]
 
   /*
   Description:
-    If the mesh does not have surface evaulation parameters,
+    If the mesh does not have surface evaluation parameters,
     has texture coordinates, and the surface parameters can
     be set in a way so the existing texture coordinates can
     be computed from the surface parameters, then this function
     sets the surface parameters.  This is useful when meshes
     that have texture coordinates and do not have surface 
-    parameters want ot set the surface parameters in a way
+    parameters want to set the surface parameters in a way
     so that the texture mapping
     ON_TextureMapping::SurfaceParameterTextureMapping
     will restore the texture coordinates.
@@ -5492,7 +5492,7 @@ public:
   Returns:
     True if no ON_Mesh is being managed by this ON_MeshRef.
   Remarks:
-    It is alwasy the case that exactly one of IsEmpty() and IsNotEmpty() is true.
+    It is always the case that exactly one of IsEmpty() and IsNotEmpty() is true.
     Both are provided so code using ON_MeshRef can be clean and easily read.
   */
   bool IsEmpty() const;
@@ -5501,7 +5501,7 @@ public:
   Returns:
     True if an ON_Mesh is being managed by this ON_MeshRef.
   Remarks:
-    It is alwasy the case that exactly one of IsEmpty() and IsNotEmpty() is true.
+    It is always the case that exactly one of IsEmpty() and IsNotEmpty() is true.
     Both are provided so code using ON_MeshRef can be clean and easily read.
   */
   bool IsNotEmpty() const;
@@ -5621,7 +5621,7 @@ public:
 
   /*
   Returns:
-    The id that corresonds to the obsolete ON::mesh_type enum value.
+    The id that corresponds to the obsolete ON::mesh_type enum value.
   Remarks:
     Ids are used to allow custom meshes to be cached.
   */
@@ -5885,7 +5885,7 @@ public:
   /*
   Returns:
     If the current iterator ngon references an ON_MeshFace
-    that is in m_mesh->m_F[] but is not explictly referenced
+    that is in m_mesh->m_F[] but is not explicitly referenced
     by an ON_MeshNgon in ON_Mesh.m_Ngon[], then true is returned.
     In this case, the ngon's m_fi[] array
     has length 1 and contains the face's index, and the ngon's
@@ -6222,7 +6222,7 @@ Parameters:
                     sides are a common source of degenerate qauds.
   input_mesh - [in] If nullptr, then the returned mesh is created
        by a class to new ON_Mesh().  If not null, then this 
-       mesh will be used to store the conrol polygon.
+       mesh will be used to store the control polygon.
 Returns:
   If successful, a pointer to a mesh.
 */

--- a/opennurbs_mesh_ngon.cpp
+++ b/opennurbs_mesh_ngon.cpp
@@ -516,7 +516,7 @@ static char* ToStringHelper( const char* src_str, char* dst_str, const char* dst
 
 static char* ToStringHelper( unsigned int u, char* dst_str, const char* dst_str_end )
 {
-  char ubuffer[32]; // unsinged int to string storage buffer
+  char ubuffer[32]; // unsigned int to string storage buffer
   unsigned int i, j;
 
   if ( ON_UNSET_UINT_INDEX == u )
@@ -2266,7 +2266,7 @@ class ON_V4V5_MeshNgon* ON_V4V5_MeshNgonList::V4V5_AddNgon(int N)
     return 0;
   ngon.vi = (int*)(blk + 1);
   ngon.fi = ngon.vi + N;
-  memset(ngon.vi,0xFF,(2*N)*sizeof(int)); // set all indicies to -1
+  memset(ngon.vi,0xFF,(2*N)*sizeof(int)); // set all indices to -1
   blk->next = m_memblk_list;
   m_memblk_list = blk;
   return &ngon;
@@ -2308,13 +2308,13 @@ public:
   ON_V4V5_MeshNgonUserData(const ON_V4V5_MeshNgonUserData&);
   ON_V4V5_MeshNgonUserData& operator=(const ON_V4V5_MeshNgonUserData&);
 
-  // vitual ON_UserData override
+  // virtual ON_UserData override
   bool IsValid( class ON_TextLog* text_log = nullptr ) const override;
   unsigned int SizeOf() const override;
   bool Write(ON_BinaryArchive&) const override;
   bool Read(ON_BinaryArchive&) override;
 
-  // vitual ON_UserData override
+  // virtual ON_UserData override
   bool GetDescription( ON_wString& ) override;
   bool Archive() const override;
 
@@ -2522,7 +2522,7 @@ bool ON_V4V5_MeshNgonUserData::Read(ON_BinaryArchive& archive)
   return rc;
 }
 
-// vitual ON_UserData override
+// virtual ON_UserData override
 bool ON_V4V5_MeshNgonUserData::GetDescription( ON_wString& description )
 {
   description = L"Mesh N-gon list";
@@ -3572,7 +3572,7 @@ static unsigned int SetFaceNeighborMap(
           break;
         }
         if ( 5 == nbr_face_side )
-          break; // we found a neighbor and are finished seaching
+          break; // we found a neighbor and are finished searching
       }
     }
   }
@@ -3708,7 +3708,7 @@ static int GetCoplanarConnectedFaces(
             break;
           }
           if ( 5 == nbr_face_side )
-            break; // we found a neighbor and are finished seaching
+            break; // we found a neighbor and are finished searching
         }
       }
     }
@@ -4350,7 +4350,7 @@ unsigned int ON_MeshNgon::FindPlanarNgons(
     {
       NgonMap.Reserve(face_count);
       NgonMap.SetCount(face_count);
-      ngonMap = NgonMap.Array(); // in case a reallocation occured.
+      ngonMap = NgonMap.Array(); // in case a reallocation occurred.
       for ( face_index = 0; face_index < face_count; face_index++ )
         ngonMap[face_index] = ON_UNSET_UINT_INDEX;
     }
@@ -4362,7 +4362,7 @@ unsigned int ON_MeshNgon::FindPlanarNgons(
     for ( face_index = 0; face_index < face_count; face_index++ )
     {
       if ( ON_UNSET_UINT_INDEX != ngonMap[face_index] )
-        continue; // this face is not eligable for being in an n-gon
+        continue; // this face is not eligible for being in an n-gon
 
       face_list.QuadFvi(face_index,Fvi);
       if ( !GetFacePlaneEquation(vertex_list,bQuadFaces,Fvi,planar_tolerance,e) )

--- a/opennurbs_mesh_tools.cpp
+++ b/opennurbs_mesh_tools.cpp
@@ -265,7 +265,7 @@ static void RemoveFaceOrVertexFromNgon(ON_Mesh& mesh, const unsigned int faceidx
         while (NewNgon.m_Vcount > ct)
         {
           idx = *vertidx;
-          // find the vertex index in the ngon's list of vertexes
+          // find the vertex index in the ngon's list of vertices
           if (idx == NewNgon.m_vi[ct])
             break;
           ct++;
@@ -541,7 +541,7 @@ bool ON_Mesh::CollapseEdge( int topei )
   for ( mei = 0; mei < me_list_count; mei++ )
   {
     // We need to set the vertex location of all mesh vertices associated with the toplogical
-    // edge or we risk "tearing apart" vertexes at corners where there are more than 2 mesh vertexes
+    // edge or we risk "tearing apart" vertices at corners where there are more than 2 mesh vertices
     // associated with the topological vertex.  Don't to this for anything but the location.
     int i;
     for (i = 0; top.m_topv[me_list[mei].topvi0].m_v_count > i; i++)

--- a/opennurbs_model_component.cpp
+++ b/opennurbs_model_component.cpp
@@ -169,7 +169,7 @@ void ON_ModelComponent::Dump(
   if (false == text_log.IsTextHash())
   {
     // m_runtime_serial_number depends on how many components have
-    // been contructed before this one. It must be suppressed when
+    // been constructed before this one. It must be suppressed when
     // calculating content hash values from text logs.
     text_log.Print("Model component %llu\n", m_runtime_serial_number);
   }
@@ -188,7 +188,7 @@ void ON_ModelComponent::Dump(
     {
       text_log.Print("Reference model = %u\n", reference_model_sn);
     }
-    // linked instance defintion model
+    // linked instance definition model
     const unsigned int idef_model_sn = InstanceDefinitionModelSerialNumber();
     if (idef_model_sn > 0)
     {
@@ -1273,7 +1273,7 @@ const ON_NameHash& ON_ModelComponent::Internal_NameHash() const
 {
   if (m_component_name_hash.IsEmptyNameHash() && m_component_name.IsNotEmpty())
   {
-    // lazy evaulation because SHA-1 calculation takes appreciable time
+    // lazy evaluation because SHA-1 calculation takes appreciable time
 
     // For components whose names are in a tree structure, like layers,
     // the parent id must be included.

--- a/opennurbs_model_component.h
+++ b/opennurbs_model_component.h
@@ -395,7 +395,7 @@ public:
 
   /*
   Returns:
-    A value identifing the model that manages this component.
+    A value identifying the model that manages this component.
   Remarks:
     If the component is being managed by a model, this value identifies the model.
     In Rhino, this value is the document runtime serial number.
@@ -408,7 +408,7 @@ public:
 
   /*
   Returns:
-    When a compoent is in a model for reference, this value identifies the
+    When a component is in a model for reference, this value identifies the
     reference model.
   Remarks:
     Reference components are not saved in .3dm archives.
@@ -442,7 +442,7 @@ public:
     and  these values are used..
             0: Active model component.
        1-1000: reserved for future use
-        >1000: linked instance defintion serial number
+        >1000: linked instance definition serial number
   */
   unsigned int InstanceDefinitionModelSerialNumber() const;
 
@@ -849,7 +849,7 @@ public:
       and linked block "Z" referencing D.3dm.
       File D.3dm contains a layer "delta", dimstyle "d1", and an embedded block "D_blk".
       
-      Reading file A.3dm will craete the following components:
+      Reading file A.3dm will create the following components:
       Layers:
         alpha
         X>B.3dm
@@ -894,7 +894,7 @@ public:
       and linked block "Z" referencing D.3dm.
       File D.3dm contains a layer "delta", dimstyle "d1", and an embedded block "D_blk".
       
-      Reading file A.3dm will craete the following components:
+      Reading file A.3dm will create the following components:
       Layers:
         alpha
         X>B.3dm
@@ -1083,7 +1083,7 @@ public:
 
   /*
   Description:
-    Remove all occurances of ON::NameReferenceDelimiter() from name.
+    Remove all occurrences of ON::NameReferenceDelimiter() from name.
   */
   static const ON_wString RemoveAllReferencePrefixDelimiters(
     const wchar_t* name
@@ -1091,7 +1091,7 @@ public:
 
   /*
   Description:
-    Remove any trailing occurance of ON_ModelComponent::NameReferenceDelimiter from name.
+    Remove any trailing occurrence of ON_ModelComponent::NameReferenceDelimiter from name.
   Example:
     "A.3dm" = ON_ModelComponent::RemoveTrailingRemoveReferencePrefixDelimiter("A.3dm : ");
   */
@@ -1101,7 +1101,7 @@ public:
 
   /*
   Description:
-    Remove any trailing occurance of ON_ModelComponent::NameReferenceSeparator from name.
+    Remove any trailing occurrence of ON_ModelComponent::NameReferenceSeparator from name.
   */
   static const ON_wString RemoveTrailingReferencePrefixSeparator(
     const wchar_t* name
@@ -1109,7 +1109,7 @@ public:
 
   /*
   Description:
-    Remove any trailing occurance of ON_ModelComponent::NamePathSeparator from name.
+    Remove any trailing occurrence of ON_ModelComponent::NamePathSeparator from name.
   */
   static const ON_wString RemoveTrailingNamePathSeparator(
     const wchar_t* name
@@ -1163,7 +1163,7 @@ public:
       or
       component_name is not empty and ON_ModelComponent::IsValidComponentName(component_name) is false.
   Remarks:
-    If component_name is nullptr or the emtpy string, the NameIsSet() state will still be true.
+    If component_name is nullptr or the empty string, the NameIsSet() state will still be true.
   */
   bool SetName(
     const wchar_t* component_name
@@ -1663,7 +1663,7 @@ public:
   ON_ModelComponentTypeIterator& operator=(const ON_ModelComponentTypeIterator&) = default;
 
   /*
-  Paramters:
+  Parameters:
     type_count - [in] number of types
     types - [in]
       list of types to iterate over
@@ -1830,7 +1830,7 @@ public:
     ONX_Model::ComponentFromRuntimeSerialNumber()
   Remarks:
     If .NET or other wrappers using "lazy garbage collection" memory management are in use,
-    there may be stale references awaiting gargage collection and this function will return
+    there may be stale references awaiting garbage collection and this function will return
     nullptr when you think it should not. 
     For this function to work reliably, the ONX_Model and its components 
     and references should be in well constructed C++ code with carefully 

--- a/opennurbs_model_geometry.cpp
+++ b/opennurbs_model_geometry.cpp
@@ -130,7 +130,7 @@ ON_ModelGeometryComponent::ON_ModelGeometryComponent( ON_ModelComponent::Type ty
 
 ON_ModelGeometryComponent::~ON_ModelGeometryComponent()
 {
-  // This destructor is explictily implemented to insure m_geometry_sp 
+  // This destructor is explicitly implemented to insure m_geometry_sp 
   // and m_attributes_sp are destroyed by the same c-runtime
   // that creates them.
 }

--- a/opennurbs_model_geometry.h
+++ b/opennurbs_model_geometry.h
@@ -113,13 +113,13 @@ public:
   Parameters:
     bManageGeometry - [in]
       If true, geometry_object was created on the heap using operator new and 
-      the ON_ModelGeometryComponent destructor will delete geometry_object. Othewise
+      the ON_ModelGeometryComponent destructor will delete geometry_object. Otherwise
       the expert caller is carefully managing the geometry_object instance and memory.
     geometry_object - [in]
       ON_Curve, ON_Surface, ON_Brep, ON_Mesh, ON_Light, annotation, detail, ...
     bManageAttributes - [in]
       If true, attributes is nullptr or was created on the heap using operator new
-      and the ON_ModelGeometryComponent destructor will delete attributes. Othewise
+      and the ON_ModelGeometryComponent destructor will delete attributes. Otherwise
       the expert caller is carefully managing the attributes instance and memory.
     attributes - [in]
       nullptr if not available

--- a/opennurbs_msbuild.Cpp.props
+++ b/opennurbs_msbuild.Cpp.props
@@ -75,7 +75,7 @@ property sheet as the first property sheet after the Microsoft boiler plate.
   <!--
   Note: 
     An <Import ...> 
-    cannot appear in a <Choose><When>...</When><Otherewise>...</Otherwise></Choose> 
+    cannot appear in a <Choose><When>...</When><Otherwise>...</Otherwise></Choose> 
     block, so the condition that checks for the existence of the property sheet
     occurs twice.  
   -->

--- a/opennurbs_nurbscurve.cpp
+++ b/opennurbs_nurbscurve.cpp
@@ -1050,7 +1050,7 @@ bool ON_NurbsCurve::ChangeClosedCurveSeam( double t )
     if ( old_dom.Includes(k,true) )
     {
       ON_NurbsCurve left, right;
-      // if periodic - dont' put fully multiple knot in middle.  
+      // if periodic - don't put fully multiple knot in middle.  
       bool bGotIt = false;
       if ( IsPeriodic() ){//This only works if the curve has only simple knots
         ON_NurbsCurve* pMovedNC = MoveSeamPeriodic(*this, t);
@@ -1579,8 +1579,8 @@ ON_NurbsCurve::Evaluate( // returns false if unable to evaluate
     // 9 November 2010 Dale Lear - ON_TuneupEvaluationParameter fix
     //   When evluation passes through ON_CurveProxy or ON_PolyCurve reparamterization
     //   and the original side parameter was -1 or +1, it is changed to -2 or +2
-    //   to indicate that if t is numerically closed to an end paramter, then
-    //   it should be tuned up to be at the end paramter.
+    //   to indicate that if t is numerically closed to an end parameter, then
+    //   it should be tuned up to be at the end parameter.
     double a = t;
     if ( ON_TuneupEvaluationParameter( side, m_knot[span_index+m_order-2], m_knot[span_index+m_order-1], &a) )
     {
@@ -2958,7 +2958,7 @@ bool TweakSplitTrimParameter(double k0, double k1, double& t )
     //
     // 2014-July-7 Dale Lear
     //  Fix RH-21610 (k0 = 5e6, k1 = k0 + 1, t = k1 - 0.2)
-    //  I changed the test Lowell referes to above.  Lowell's 4.0*ON_SQRT_EPSILON 
+    //  I changed the test Lowell refers to above.  Lowell's 4.0*ON_SQRT_EPSILON 
     //  is now 8.0*ON_EPSILON in the ktol2 initialization value.
     //  I added ktol1 base on the span length.  
     //  If you modify this code in the future, please reference a bug with sample 

--- a/opennurbs_nurbscurve.h
+++ b/opennurbs_nurbscurve.h
@@ -102,7 +102,7 @@ public:
   Parameters:
     other - [in] other NURBS curve
     bIgnoreParameterization - [in] if true, parameterization
-             and orientaion are ignored.
+             and orientation are ignored.
     tolerance - [in] tolerance to use when comparing
                      control points.
   Returns:
@@ -723,7 +723,7 @@ public:
   Returns:
     ON_DBL_QNAN: no bezier surface is returned.
     If a bezier surface is returned, then the maximum deviation between 
-    the bezier suface this NURBS surface sampled at the Greville abcissa.
+    the bezier surface this NURBS surface sampled at the Greville abcissa.
   */
   double GetCubicBezierApproximation(
     double max_deviation,
@@ -983,7 +983,7 @@ public:
 
   // Description:
   //   Clamp end knots.  Does not modify the curve location, but can modify
-  //   knots and control verticies near the ends.
+  //   knots and control vertices near the ends.
   // Parameters:
   //   end - [in] 0 = clamp start, 1 = clamp end, 2 = clamp start and end
   // Returns:
@@ -1029,7 +1029,7 @@ public:
   /*
   Returns:
     If this class is managing m_cv, then CVCapacity() is the number of doubles
-    m_cv[] can accomodate. Otherwise, CVCapacity() is 0.
+    m_cv[] can accommodate. Otherwise, CVCapacity() is 0.
   */
   int CVCapacity() const;
 
@@ -1040,13 +1040,13 @@ public:
   /*
   Returns:
     If this class is managing m_knot, then KnotCapacity() is the number of doubles
-    m_knot[] can accomodate. Otherwise, KnotCapacity() is 0.
+    m_knot[] can accommodate. Otherwise, KnotCapacity() is 0.
   */
   int KnotCapacity() const;
 
   /*
   Description:
-    Unconditionally transfer knot managment to caller and zero m_knot and KnotCapacity().
+    Unconditionally transfer knot management to caller and zero m_knot and KnotCapacity().
   Parameters:
     knot_capacity - [out]
       knot_capacity is set to input value of KnotCapacity() and then KnotCapacity() is set to 0.
@@ -1092,7 +1092,7 @@ public:
       ) const;
 
   /*
-  Paramaters:
+  Parameters:
     span_index - [in]
       The index of a non-empty span to test.
         span_index >= 0
@@ -1118,7 +1118,7 @@ public:
   bool IsSingular() const;
 
   /*
-  Paramaters:
+  Parameters:
     span_index - [in]
       The index of a non-empty span to remove.
         span_index >= 0
@@ -1156,7 +1156,7 @@ public:
   Description:
     Clamps ends and adds knots so the NURBS curve has bezier spans 
    (all distinct knots have multiplitity = degree).
-  Paremeters:
+  Parameters:
     bSetEndWeightsToOne - [in] If true and the first or last weight is
        not one, then the first and last spans are reparameterized so 
        that the end weights are one.
@@ -1264,7 +1264,7 @@ public:
                             //   Rational control vertices use homogeneous form
                             //   and explicit weight values are in m_cv[] array.
                             // 0 for non-rational B-splines.
-                            //   Control verticies have an implicit weight value
+                            //   Control vertices have an implicit weight value
                             //   of 1.0.  An explicit weight value is not
                             //   set in the m_cv[] array.
 

--- a/opennurbs_nurbssurface.cpp
+++ b/opennurbs_nurbssurface.cpp
@@ -1210,13 +1210,13 @@ bool ON_NurbsSurface::Split(
   return true;  
 }
 
-// virutal ON_Surface::HasNurbForm() override
+// virtual ON_Surface::HasNurbForm() override
 int ON_NurbsSurface::HasNurbForm() const
 {
   return 1;
 }
 
-// virutal ON_Surface::GetNurbForm() override
+// virtual ON_Surface::GetNurbForm() override
 int ON_NurbsSurface::GetNurbForm(
       ON_NurbsSurface& srf,
       double // tolerance

--- a/opennurbs_nurbssurface.h
+++ b/opennurbs_nurbssurface.h
@@ -112,7 +112,7 @@ public:
   Parameters:
     other - [in] other NURBS surface
     bIgnoreParameterization - [in] if true, parameterization
-             and orientaion are ignored.
+             and orientation are ignored.
     tolerance - [in] tolerance to use when comparing
                      control points.
   Returns:
@@ -375,7 +375,7 @@ public:
               possible to repeatedly call GetNextDiscontinuity
               and step through the discontinuities.
     t1 - [in] (t0 != t1)  If there is a discontinuity at t1 is 
-              will be ingored unless c is a locus discontinuity
+              will be ignored unless c is a locus discontinuity
               type and t1 is at the start or end of the curve.
     t - [out] if a discontinuity is found, then *t reports the
           parameter at the discontinuity.
@@ -386,7 +386,7 @@ public:
         discontinuity found at *t.  A value of 1 means the first 
         derivative or unit tangent was discontinuous.  A value 
         of 2 means the second derivative or curvature was 
-        discontinuous.  A value of 0 means teh curve is not
+        discontinuous.  A value of 0 means the curve is not
         closed, a locus discontinuity test was applied, and
         t1 is at the start of end of the curve.
     cos_angle_tolerance - [in] default = cos(1 degree) Used only
@@ -630,7 +630,7 @@ public:
   Returns:
     ON_DBL_QNAN: no bezier surface is returned.
     If a bezier surface is returned, then the maximum deviation between 
-    the bezier suface this NURBS surface sampled at the Greville abcissa.
+    the bezier surface this NURBS surface sampled at the Greville abcissa.
   */
   double GetCubicBezierApproximation(
     double max_deviation,
@@ -649,7 +649,7 @@ public:
   Returns:
     ON_DBL_QNAN: no bezier surface is returned.
     If a bezier surface is returned, then the maximum deviation between 
-    the bezier suface this NURBS surface sampled at the Greville abcissa.
+    the bezier surface this NURBS surface sampled at the Greville abcissa.
   */
   double GetCubicBezierApproximation(
     double max_deviation,
@@ -1125,7 +1125,7 @@ public:
   int     m_is_rat;         // 1 for rational B-splines. (Control vertices
                             // use homogeneous form.)
                             // 0 for non-rational B-splines. (Control
-                            // verticies do not have a weight coordinate.)
+                            // vertices do not have a weight coordinate.)
 
   int     m_order[2];       // order = degree+1 (>=2)
 
@@ -1342,7 +1342,7 @@ public:
   Description:
     Overrides virtual ON_Geometry::IsDeformable function.
   Returns:
-    True because a NURBS volume can be accuratly modified 
+    True because a NURBS volume can be accurately modified 
     with "squishy" transformations like projections, 
     shears, an non-uniform scaling.
   */
@@ -1932,7 +1932,7 @@ public:
 
   /*
   Description:
-    Adds localizer with support near the controling NURBS object.
+    Adds localizer with support near the controlling NURBS object.
   Parameters:
     support_distance - [in] >= 0
       If the distance a point to the controls NURBS 

--- a/opennurbs_nurbsvolume.cpp
+++ b/opennurbs_nurbsvolume.cpp
@@ -2147,7 +2147,7 @@ bool ON_MorphControl::IsValid( ON_TextLog* text_log ) const
 
 void ON_MorphControl::Dump( ON_TextLog& text_log ) const
 {
-  text_log.Print("Varient: %d\n",m_varient);
+  text_log.Print("Variant: %d\n",m_varient);
   text_log.Print("Control object:\n");
   text_log.PushIndent();
   switch(m_varient)

--- a/opennurbs_object.cpp
+++ b/opennurbs_object.cpp
@@ -100,10 +100,10 @@ static int ON__isnand(const double* x)
     }
     else
     {
-      // This sitation is not handled by this algorithm
+      // This situation is not handled by this algorithm
       // and that is a bug in the algorithm.
       ON_ERROR("Unexpected bit pattern in double 2.0.");
-      // assum little endian doubles
+      // assume little endian doubles
       b7 = 7;
       b6 = 6;
     }
@@ -175,7 +175,7 @@ static int ON__isnanf(const float* x)
     }
     else
     {
-      // This sitation is not handled by this algorithm
+      // This situation is not handled by this algorithm
       // and that is a bug in the algorithm.
       ON_ERROR("Unexpected bit pattern in float 2.0f.");
       // assume little endian floats
@@ -258,7 +258,7 @@ void ON_DBL_SNAN( double* x)
   }
   else
   {
-    // this sitation is not handled by this algorithm
+    // this situation is not handled by this algorithm
     // and that is a bug in the algorithm.
     ON_ERROR("CPU has unexpected bit pattern in double 2.0.");
     i7 = 0;
@@ -286,7 +286,7 @@ void ON_DBL_SNAN( double* x)
 
 
   // must use memcpy().  On Intel FPU, assignment using x = u.x 
-  // will set x to qnan and invalid op exception occures.
+  // will set x to qnan and invalid op exception occurs.
   memcpy(x,&u.x,sizeof(*x));
 }
 
@@ -321,7 +321,7 @@ void ON_FLT_SNAN( float* x)
   }
   else
   {
-    // this sitation is not handled by this algorithm
+    // this situation is not handled by this algorithm
     // and that is a bug in the algorithm.
     ON_ERROR("CPU has unexpected bit pattern in float 2.0f.");
     memset(&x,0xFF,sizeof(*x));
@@ -342,7 +342,7 @@ void ON_FLT_SNAN( float* x)
 #endif
 
   // must use memcpy().  On Intel FPU, assignment using x = u.x 
-  // will set x to qnan and invalid op exception occures.
+  // will set x to qnan and invalid op exception occurs.
   memcpy(x,&u.x,sizeof(*x));
 }
 
@@ -840,7 +840,7 @@ ON_UUID ON_GetMostRecentClassIdCreateUuid()
 ON_Object* ON_ClassId::Create() const
 {
   // Save the uuid so that Rhino's .NET SDK
-  // can create approprate class.  The C++
+  // can create appropriate class.  The C++
   // opennurbs toolkit never uses this value.
   s_most_recent_class_id_create_uuid = m_uuid;
   return m_create ? m_create() : 0;
@@ -1783,7 +1783,7 @@ bool ON_Object::ThisIsNullptr(
   bool bSilentError
 ) const
 {
-  // CLang warns that these tests may be ommitted because in "well-defined C++ code"
+  // CLang warns that these tests may be omitted because in "well-defined C++ code"
   // they are always false. 
   //
   // Earth to CLang: 

--- a/opennurbs_object.h
+++ b/opennurbs_object.h
@@ -155,7 +155,7 @@ public:
     const ON_ClassId* potential_parent
     ) const;
 
-  // Descrption:
+  // Description:
   //   Use the default constructor to create an instance of the
   //   class on the heap.
   // Returns:
@@ -187,14 +187,14 @@ private:
   const ON_ClassId* m_pBaseClassId;  // base class id
   char m_sClassName[80];              
   char m_sBaseClassName[80];
-  // m_create points to a function that calls the default constuctor.
+  // m_create points to a function that calls the default constructor.
   // m_create() is used to create classes from uuids when reading files.
   ON_Object* (*m_create)(); 
   ON_UUID m_uuid;
   int m_mark; // bit 0x80000000 is used to indicate new extensions
 
 private:
-  // There are no implementaions of the default constructor, copy constructor
+  // There are no implementations of the default constructor, copy constructor
   // or operator=() to prohibit use.
   ON_ClassId();
   ON_ClassId( const ON_ClassId&);
@@ -209,7 +209,7 @@ private:
 
   // The m_f[] pointers provide a way add a "virtual" function to
   // a class derived from ON_Object without breaking the SDK.
-  // At each SDK breaking relase, any functions that use this
+  // At each SDK breaking release, any functions that use this
   // mechanism are made into C++ virtual functions on the appropriate
   // classes. Currently, none of these are in use.
   unsigned int m_class_id_version; 
@@ -283,10 +283,10 @@ a .cpp file.
     /* OpenNURBS class run-time type information */       \
     static const ON_ClassId m_##cls##_class_rtti;         \
                                                           \
-    /*OpenNURBS platfrom independent dynamic cast*/       \
+    /*OpenNURBS platform independent dynamic cast*/       \
     static cls * Cast( ON_Object* );                      \
                                                           \
-    /*OpenNURBS platfrom independent dynamic cast*/       \
+    /*OpenNURBS platform independent dynamic cast*/       \
     static const cls * Cast( const ON_Object* );          \
                                                           \
     /*Returns: OpenNURBS run-time type information.*/     \
@@ -510,7 +510,7 @@ public:
     static Cast() members declared in the ON_OBJECT_DECLARE
     macro.  If we determine that dynamic_cast is properly 
     supported and implemented by all supported compilers, 
-    then IsKindOf() may dissappear.  If an application needs
+    then IsKindOf() may disappear.  If an application needs
     to determine if a pointer points to a class derived from
     ON_SomeClassName, then call 
     ON_SomeClassName::Cast(mystery pointer) and check for 
@@ -527,7 +527,7 @@ public:
   Parameters:
     text_log - [in] if the object is not valid and text_log
         is not nullptr, then a brief englis description of the
-        reason the object is not valid is appened to the log.
+        reason the object is not valid is appended to the log.
         The information appended to text_log is suitable for 
         low-level debugging purposes by programmers and is 
         not intended to be useful as a high level user 
@@ -868,7 +868,7 @@ public:
   Description:
     When a userdata item is copied or moved from a source object to
     a destination object, the ON_Object::UserDataConflictResolution
-    enum values specify how conficts are resolved.
+    enum values specify how conflicts are resolved.
   Remark:
     A userdata item "conflict" occurs when both the destination
     and source object have a user data item with the same
@@ -896,7 +896,7 @@ public:
       If source_userdata_item_id  is not nil, then only the user data item
       with a matching ON_UserData.m_userdata_uuid value will be copied.
     userdata_conflict_resolution - [in]
-      method to resolve userdata item conficts.
+      method to resolve userdata item conflicts.
   Remarks:
     Generally speaking you don't need to use CopyUserData().
     Simply rely on ON_Object::operator=() or the copy constructor
@@ -920,7 +920,7 @@ public:
       If source_userdata_item_id  is not nil, then only the user data item
       with a matching ON_UserData.m_userdata_uuid value will be moved.
     userdata_conflict_resolution - [in]
-      method to resolve userdata item conficts.
+      method to resolve userdata item conflicts.
     bDeleteAllSourceItems - [in]
       If bDeleteAllSourceItems is true, then any userdata items
       that are not copied from source_object are deleted.
@@ -1106,7 +1106,7 @@ public:
 
   /*
   Description:
-    Call whenever a component status setting is modifed 
+    Call whenever a component status setting is modified 
     by directly changing it on a component in a way that
     will result in any saved information about the parent
     object's aggretate component status becoming invalid.
@@ -1123,7 +1123,7 @@ public:
 
   /*
   Description:
-    Call whenever a component status setting is modifed 
+    Call whenever a component status setting is modified 
     by directly changing it on a component in a way that
     will result in any saved information about the parent
     object's aggretate component status becoming invalid.
@@ -1147,7 +1147,7 @@ public:
     ci_list_count - [in]
       Number of elements in the ci_list[] array.
   Returns:
-    True: succesful
+    True: successful
     False: failure - no changes.
   */
   virtual

--- a/opennurbs_object_history.cpp
+++ b/opennurbs_object_history.cpp
@@ -2809,7 +2809,7 @@ bool ON_HistoryRecord::Write(ON_BinaryArchive& archive) const
 bool ON_HistoryRecord::Internal_WriteV5( ON_BinaryArchive& archive ) const
 {
   // 2015-06-01 Dale Lear
-  //   Save m_bCopyOnReplaceObject in the file in chunck version 1.2
+  //   Save m_bCopyOnReplaceObject in the file in chunk version 1.2
 
   const int minor_version 
     = (archive.Archive3dmVersion() >= 60)

--- a/opennurbs_object_history.h
+++ b/opennurbs_object_history.h
@@ -253,7 +253,7 @@ public:
   int GetPolyEdgeValues( int value_id, ON_SimpleArray<const ON_PolyEdgeHistory*>& ) const;
 
   /*
-  Desccription:
+  Description:
     Determine if object is an antecedent (input) in this
     history record.
   Parameters:

--- a/opennurbs_offsetsurface.h
+++ b/opennurbs_offsetsurface.h
@@ -141,7 +141,7 @@ public:
   /*
   Description:
     Sets the offset distance at a point.  Call this function
-    once for each point wher the user specifies an offset.
+    once for each point where the user specifies an offset.
   Parameters:
     s - [in]
     t - [in] (s,t) is a base surface evaluation parameter

--- a/opennurbs_optimize.cpp
+++ b/opennurbs_optimize.cpp
@@ -291,7 +291,7 @@ ON_LocalZero1::BracketSpan( double s0, double f0, double s1, double f1 )
       i0++;
     if ( i0 <= i1 ) {
       // we have s0 < m_k[i0] <= ... <= m_k[i1] < s1
-      Evaluate( m_k[i0], &fm, nullptr,-1 ); // gaurd against C0 discontinuities
+      Evaluate( m_k[i0], &fm, nullptr,-1 ); // guard against C0 discontinuities
       Evaluate( m_k[i0], &fp, nullptr, 1 );
       if ( (f0 <= 0.0 && fm >= 0.0) || (f0 >= 0.0 && fm <= 0.0) ) {
         m_s1 = m_k[i0];
@@ -580,7 +580,7 @@ bool ON_LocalZero1::NewtonRaphson( double s0, double f0,
 
     if ( fabs(s1-s0) <= m_t_tolerance ) {
       // a root has been bracketed to an interval that is small enough
-      // to satisify user.
+      // to satisfy user.
       *t = (fabs(f0) <= fabs(f1)) ? s0 : s1;
       return true;
     }

--- a/opennurbs_parse.h
+++ b/opennurbs_parse.h
@@ -503,7 +503,7 @@ public:
 
   /*
   Description:
-    The default constuctor uses the default settings.
+    The default constructor uses the default settings.
   */
   ON_ParseSettings();
 
@@ -598,10 +598,10 @@ public:
     ON_ParseSetting::FalseSettings has all parsing options
     set to false.
   Remarks:
-    A common use of ON_ParseSettings FalseSettings is to intialize
+    A common use of ON_ParseSettings FalseSettings is to initialize
     ON_ParseSettings classes that are used to report what happened
     during parsing. Any parsing results value set to true after 
-    parsing indicates that type of parsing occured.
+    parsing indicates that type of parsing occurred.
   */
   static const ON_ParseSettings FalseSettings;
 
@@ -831,7 +831,7 @@ public:
       for example sin(pi/4).
     - The angle parameters to trigonometry functions may have angle
       units specified.  For example, sin(30degrees).  If no angle
-      unit is specified, the nubmer is assumed to be in radians.
+      unit is specified, the number is assumed to be in radians.
   */
   bool ParseMathFunctions() const;
 
@@ -1131,7 +1131,7 @@ public:
     L"\x03C0" (unicode greek small letter pi) 
     will be parsed as if they were "3.141592653589793238462643".
     In addition, if the pi strings appear next to something that
-    is parsed as a number, the result will be mulitplied by pi. 
+    is parsed as a number, the result will be multiplied by pi. 
     For example, 
       "3pi" and pi3.0 will return 3.0*ON_PI. 
       If division parsing is enabled, then "3pi/4" and 3/4pi" will
@@ -1323,7 +1323,7 @@ public:
   /*
   Returns:
     The Microsoft locale id that identifies the locale that should
-    be used to resolve ambiguous parsing situtations. The default
+    be used to resolve ambiguous parsing situations. The default
     value is zero, which means ambiguous situations are not parsed.
   Example:
     When parsing angles, the string "Grad" is ambiguous. 
@@ -1408,7 +1408,7 @@ public:
   Parameters:
     c - [in]
   Returns:
-    Returns '0' throught '9' if c is a digit, otherwise returns 0.
+    Returns '0' through '9' if c is a digit, otherwise returns 0.
   */
   char IsDigit(ON__UINT32 c) const;
 
@@ -1548,7 +1548,7 @@ public:
   /*
   Parameters:
     bParseExplicitFormulaExpression - [in]
-      True if explicity formulae should be parsed.
+      True if explicitly formulae should be parsed.
   Remarks:
     See ON_ParseSettings::ParseExplicitFormulaExpression()
     for details about this property.
@@ -1859,22 +1859,22 @@ public:
 
   /*
   Description:
-    Set the prefered locale id for parsing unit names.  This local
+    Set the preferred locale id for parsing unit names.  This local
     id is used to resolve ambiguous unit names.
 
   Parameters:
     prefered_locale_id - [in]
       The Microsoft locale id that identifies the locale that should
-      be used to resolve ambiguous parsing situtations.  The default
+      be used to resolve ambiguous parsing situations.  The default
       value is zero, which means ambiguous situations are not parsed.
 
   Example:
     When parsing angles, the string "Grad" is ambiguous. 
     In German "Grad" identifies arc degree angle units and in
     English "Grad" identifies gradian angle units. If angle parsing
-    encounters "Grad" and the prefered locale id is 1031 (de-de),
+    encounters "Grad" and the preferred locale id is 1031 (de-de),
     then parsing reports the angle value as arc degree units.
-    If angle parsing encounters "Grad" and the prefered locale id 
+    If angle parsing encounters "Grad" and the preferred locale id 
     is 1033 (en-us), then parsing reports the angle values as
     gradian units.
   */
@@ -2030,7 +2030,7 @@ private:
   // If m_context_length_unit_system is 0, then it is ignored.
   // If m_context_length_unit_system is not 0 and is equal to an
   // ON::LengthUnitSystem value, that length unit system is used.
-  // Presently this value is not relavent to internal parsing code,
+  // Presently this value is not relevant to internal parsing code,
   // but may be passed along in parse settings to code that
   // use parsing.
   ON__UINT8 m_context_length_unit_system = 0;
@@ -2116,7 +2116,7 @@ Parameters:
    The value of the parsed number.
 
 Returns:
-  Number of elments of str[] that were parsed. 
+  Number of elements of str[] that were parsed. 
   A return value of 0 indicates that str[] could not be 
   parsed as a number.
 
@@ -2167,7 +2167,7 @@ Parameters:
    The value of the parsed number.
 
 Returns:
-  Number of elments of str[] that were parsed. 
+  Number of elements of str[] that were parsed. 
   A return value of 0 indicates that str[] could not be 
   parsed as a number.
 
@@ -2197,7 +2197,7 @@ Parameters:
     If str_count >= 0. it specifies the maximum number of elements in str[]
     that may be parsed.  If str_count = -1, then the string must contain a 
     character that terminates unit system name parsing.  This character can
-    be a null, digit, punctuation, aritmetic operator, or a unicode 
+    be a null, digit, punctuation, arithmetic operator, or a unicode 
     code point <= 0x0020 (0x0020 = space = 32 decimal).
 
   prefered_locale_id - [in]
@@ -2217,7 +2217,7 @@ Parameters:
 
 
 Returns:
-  Number of elments of str that were parsed. A return value of
+  Number of elements of str that were parsed. A return value of
   0 indicates that str did not match know unit system names or 
   abbreviations.
 
@@ -2226,12 +2226,12 @@ Remarks:
   meters and kilometers are supported in Czech (cs-*), English (en-*),
   French (fr-*), German (de-*), Portuguese (pt-*) and Spanish (es-*).
 
-  Common names and abreviations for the following United States customary
+  Common names and abbreviations for the following United States customary
   length units are supported in United States English (en-US). 
     If the first element of str is quotation mark (double quote), unicode 
-    code point 0x0022, the string is parsed as United Sates customary inch.
+    code point 0x0022, the string is parsed as United States customary inch.
     If the first element of str is apostrophe, unicode code point 0x0027, 
-    the string is parsed as United Sates customary foot. 
+    the string is parsed as United States customary foot. 
     All conversions to meters are exact.
       microinch =    2.54e-8 meters (1.0e-6 inches)
       mil       =    2.54e-5 meters (0.001 inches)
@@ -2364,7 +2364,7 @@ Parameters:
     If str_count >= 0. it specifies the maximum number of elements in str[]
     that may be parsed.  If str_count = -1, then the string must contain a 
     character that terminates angle unit system name parsing.  
-    This character can be a null, digit, punctuation, aritmetic operator,
+    This character can be a null, digit, punctuation, arithmetic operator,
     or a unicode code point <= 0x0020 (0x0020 = space = 32 decimal).
 
   prefered_locale_id - [in]
@@ -2386,7 +2386,7 @@ Parameters:
     ON::AngleUnitSystem::None.
 
 Returns:
-  Number of elments of str that were parsed. A return value of
+  Number of elements of str that were parsed. A return value of
   0 indicates that str did not match know unit system names or 
   abbreviations.
 

--- a/opennurbs_parse_number.cpp
+++ b/opennurbs_parse_number.cpp
@@ -988,7 +988,7 @@ static int ON_ParseFunctionHelper(
     if ( f_parameter_capacity < f->m_function_parameter_count )
       break;
 
-    // The angle parameters passed to trig functions alwasy have
+    // The angle parameters passed to trig functions always have
     // an "implicit" angle system of radians. It is intentional that
     // this cannot be changed by parse settings.  The reason is
     // to insure that the same script will create the same values
@@ -1059,7 +1059,7 @@ int ON_ParseNumberExpression(
   )
 {
   // Please discuss changes with Dale Lear.
-  // Do not make this funtion recursive.
+  // Do not make this function recursive.
   // This function support parsing limited arithmetic expressions.
   ON_ParseSettings input_parse_settings(parse_settings);
   
@@ -1790,7 +1790,7 @@ int ON_ParseAngleExpression(
     if ( ON::AngleUnitSystem::None == angle_us )
     {
       // Surveyor's notation implies degrees when no angle unit
-      // is explictly supplied.  This is done because it is
+      // is explicitly supplied.  This is done because it is
       // difficult for many users to enter a degree symbol
       // when typing input and Surveyor's notation is almost
       // always in degrees. [TODO cite reference].

--- a/opennurbs_parse_settings.cpp
+++ b/opennurbs_parse_settings.cpp
@@ -223,7 +223,7 @@ ON_ParseSettings& ON_ParseSettings::operator|=(const ON_ParseSettings& other)
 
   if (0 == m_context_length_unit_system)
   {
-    // "this" wins if it alread has a locale id.
+    // "this" wins if it already has a locale id.
     // The reason is that the |= operator is used to add
     // a property to "this" when its current
     // property has a "false" value.
@@ -232,7 +232,7 @@ ON_ParseSettings& ON_ParseSettings::operator|=(const ON_ParseSettings& other)
 
   if (0 == m_context_angle_unit_system)
   {
-    // "this" wins if it alread has a locale id.
+    // "this" wins if it already has a locale id.
     // The reason is that the |= operator is used to add
     // a property to "this" when its current
     // property has a "false" value.
@@ -241,7 +241,7 @@ ON_ParseSettings& ON_ParseSettings::operator|=(const ON_ParseSettings& other)
 
   if (0 == m_context_locale_id)
   {
-    // "this" wins if it alread has a locale id.
+    // "this" wins if it already has a locale id.
     // The reason is that the |= operator is used to add
     // a property to "this" when its current
     // property has a "false" value.
@@ -274,7 +274,7 @@ ON_ParseSettings& ON_ParseSettings::operator&=(const ON_ParseSettings& other)
   if ( m_context_locale_id != other.m_context_locale_id )
   {
     // If m_context_locale_id != other.m_context_locale_id 
-    // identify the same language, then preserve the lauguage.
+    // identify the same language, then preserve the language.
     // This is useful when parsing unit names, particularly in
     // English where en-US SI unit names end in "er" and many 
     // other en-* SI unit names end in "re".  Setting 

--- a/opennurbs_plane.cpp
+++ b/opennurbs_plane.cpp
@@ -389,7 +389,7 @@ bool ON_Plane::Transform( const ON_Xform& xform )
 
   ON_3dPoint origin_pt = xform*origin;
 
-  // use care tranforming vectors to get
+  // use care transforming vectors to get
   // maximum precision and the right answer
   bool bUseVectorXform = (    0.0 == xform.m_xform[3][0] 
                            && 0.0 == xform.m_xform[3][1]

--- a/opennurbs_plane.h
+++ b/opennurbs_plane.h
@@ -24,7 +24,7 @@ public:
   /*
   Description:
     The default constructor creates a plane
-    with orgin=(0,0,0), xaxis=(1,0,0), yaxis=(0,1,0)
+    with origin=(0,0,0), xaxis=(1,0,0), yaxis=(0,1,0)
     zaxis=(0,0,1), and equation=(0,0,1,0).
   */
   ON_Plane();
@@ -286,7 +286,7 @@ public:
     Evaluate a point on the plane
   Parameters:
     u - [in]
-    v - [in] evaulation parameters
+    v - [in] evaluation parameters
   Returns:
     plane.origin + u*plane.xaxis + v*plane.yaxis
   */

--- a/opennurbs_planesurface.h
+++ b/opennurbs_planesurface.h
@@ -186,7 +186,7 @@ public:
               possible to repeatedly call GetNextDiscontinuity
               and step through the discontinuities.
     t1 - [in] (t0 != t1)  If there is a discontinuity at t1 is 
-              will be ingored unless c is a locus discontinuity
+              will be ignored unless c is a locus discontinuity
               type and t1 is at the start or end of the curve.
     t - [out] if a discontinuity is found, then *t reports the
           parameter at the discontinuity.
@@ -197,7 +197,7 @@ public:
         discontinuity found at *t.  A value of 1 means the first 
         derivative or unit tangent was discontinuous.  A value 
         of 2 means the second derivative or curvature was 
-        discontinuous.  A value of 0 means teh curve is not
+        discontinuous.  A value of 0 means the curve is not
         closed, a locus discontinuity test was applied, and
         t1 is at the start of end of the curve.
     cos_angle_tolerance - [in] default = cos(1 degree) Used only

--- a/opennurbs_pluginlist.h
+++ b/opennurbs_pluginlist.h
@@ -29,7 +29,7 @@ class ON_CLASS ON_PlugInRef
 public:
   ON_PlugInRef();
 
-  // executable informtion
+  // executable information
   ON_UUID m_plugin_id;
   int m_plugin_type; // CRhinoPlugIn::plugin_type enum value
   int m_plugin_platform; // 0 = unknown, 1 = C++, 2 = .NET

--- a/opennurbs_point.cpp
+++ b/opennurbs_point.cpp
@@ -5786,7 +5786,7 @@ double ON_Length2d( double x, double y )
   //     For small denormalized doubles (positive but smaller
   //     than DBL_MIN), some compilers/FPUs set 1.0/fx to +INF.
   //     Without the ON_DBL_MIN test we end up with
-  //     microscopic vectors that have infinte length!
+  //     microscopic vectors that have infinite length!
   //
   //     This code is absolutely necessary.  It is a critical
   //     part of the bug fix for RR 11217.
@@ -6391,7 +6391,7 @@ double ON_Length3d(double x, double y, double z)
   //     For small denormalized doubles (positive but smaller
   //     than DBL_MIN), some compilers/FPUs set 1.0/x to +INF.
   //     Without the ON_DBL_MIN test we end up with
-  //     microscopic vectors that have infinte length!
+  //     microscopic vectors that have infinite length!
   //
   //     This code is absolutely necessary.  It is a critical
   //     part of the bug fix for RR 11217.
@@ -7898,7 +7898,7 @@ bool ON_IsDegenrateConicHelper(double A, double B, double C, double D, double E)
   // (F = 0 in our case here.)
 
   // zero_tol was tuned by 
-  //  1) testing sets of equaly spaced collinear 
+  //  1) testing sets of equally spaced collinear 
   //     points with coordinate sizes ranging from 0.001 to 1.0e4 and
   //     segment lengths from 0.001 to 1000.0.
   //  2) testing ellipses with axes lengths ranging from 0.001 to 1000
@@ -7990,7 +7990,7 @@ bool ON_GetConicEquationThrough6Points(
         double* zero_pivot
         )
 {
-  // Sets conic[] to the coefficents = (A,B,C,D,E,F), 
+  // Sets conic[] to the coefficients = (A,B,C,D,E,F), 
   // such that A*x*x + B*x*y + C*y*y + D*x + E*y + F = 0
   // for each of the 6 input points.
 
@@ -8393,7 +8393,7 @@ bool ON_GetConicEquationThrough6Points(
 
   if ( (fabs(A) >= fabs(C)) ? (A<0.0):(C<0.0) )
   {
-    // Make the largest A/C coefficent positive.
+    // Make the largest A/C coefficient positive.
     A = -A; B = -B; C = -C; D = -D; E = -E; F = -F;
   }
 
@@ -8484,7 +8484,7 @@ bool ON_IsConicEquationAnEllipse(
   P[0] = x0*X[0] + y0*Y[0];
   P[1] = x0*X[1] + y0*Y[1];
 
-  // set A and C to elipse axes lengths
+  // set A and C to ellipse axes lengths
   F = conic[5] -(A*x0*x0 + C*y0*y0);
   if ( !(0.0 != F) )
     return false; // F is 0.0 or a NaN

--- a/opennurbs_point.h
+++ b/opennurbs_point.h
@@ -354,7 +354,7 @@ public:
 
   explicit ON_2dPoint(double x,double y);
 #if defined(OPENNURBS_WALL)
-  // Goal is to eventually have all constructors that discard informtion be explicit.
+  // Goal is to eventually have all constructors that discard information be explicit.
   explicit 
 #endif
   ON_2dPoint(const ON_3dPoint& );       // from 3d point
@@ -443,7 +443,7 @@ public:
 
   /*
   Returns:
-    False if any coordinate is infinte, a nan, or ON_UNSET_VALUE.
+    False if any coordinate is infinite, a nan, or ON_UNSET_VALUE.
   */
   bool IsValid() const;
 
@@ -563,7 +563,7 @@ public:
 public:
   explicit ON_3dPoint(double x,double y,double z);
 #if defined(OPENNURBS_WALL)
-  // Goal is to eventually have all constructors that discard informtion be explicit.
+  // Goal is to eventually have all constructors that discard information be explicit.
   explicit 
 #endif
   ON_3dPoint(const ON_2dPoint& );       // from 2d point
@@ -649,7 +649,7 @@ public:
 
   /*
   Returns:
-    False if any coordinate is infinte, a nan, or ON_UNSET_VALUE.
+    False if any coordinate is infinite, a nan, or ON_UNSET_VALUE.
   */
   bool IsValid() const;
 
@@ -786,7 +786,7 @@ public:
 
   explicit ON_4dPoint(double x,double y,double z,double w);
 
-  // These constructors are not explicit because no informtion is lost.
+  // These constructors are not explicit because no information is lost.
   ON_4dPoint(const ON_2dPoint& );     // from 2d point (z,y,0,1)
   ON_4dPoint(const ON_3dPoint& );     // from 3d point (x,y,z,1)
   ON_4dPoint(const ON_2dVector& );    // from 2d vector (x,y,0,0)
@@ -794,7 +794,7 @@ public:
 
   explicit ON_4dPoint(const double*);          // from double[4] array
 
-  // These constructors are not explicit because no informtion is lost.
+  // These constructors are not explicit because no information is lost.
   ON_4dPoint(const ON_2fPoint& );     // from 2f point (z,y,0,1)
   ON_4dPoint(const ON_3fPoint& );     // from 3f point (x,y,z,1)
   ON_4dPoint(const ON_4fPoint& );     // from 4f point
@@ -806,7 +806,7 @@ public:
   /*
   Description:
     This function is provided because in rare cases it makes sense.
-    If you are not certian why you want this value, think carefully
+    If you are not certain why you want this value, think carefully
     or work with vectors and points in Euclidean coordinates.
   Returns:
     lhs.x*rhs.x + lhs.y*rhs.y + lhs.z*rhs.z + lhs.w*rhs.w;
@@ -896,7 +896,7 @@ public:
 
   /*
   Returns:
-    False if any coordinate is infinte, a nan, or ON_UNSET_VALUE.
+    False if any coordinate is infinite, a nan, or ON_UNSET_VALUE.
   */
   bool IsValid() const;
 
@@ -1069,7 +1069,7 @@ public:
 
   /*
   Returns:
-    False if any coordinate is infinte, a nan, or ON_UNSET_VALUE.
+    False if any coordinate is infinite, a nan, or ON_UNSET_VALUE.
   */
   bool IsValid() const;
 
@@ -1410,7 +1410,7 @@ public:
 
   /*
   Returns:
-    False if any coordinate is infinte, a nan, or ON_UNSET_VALUE.
+    False if any coordinate is infinite, a nan, or ON_UNSET_VALUE.
   */
   bool IsValid() const;
 
@@ -1550,7 +1550,7 @@ public:
       vector to return if this is zero or unset.
       When in doubt, pass ON_3dVector::NanVector.
   Returns:
-    If this is nonzero, a vector perpindicular to this.
+    If this is nonzero, a vector perpendicular to this.
     The returned vector is not unitized.
     Otherwise failure_result is returned.
   */
@@ -1593,7 +1593,7 @@ Description:
 class ON_CLASS ON_PlaneEquation
 {
 public:
-  // C++ defaults for construction, destruction, copys, and operator=
+  // C++ defaults for construction, destruction, copies, and operator=
   // work fine.
 
   static const ON_PlaneEquation UnsetPlaneEquation; // (ON_UNSET_VALUE,ON_UNSET_VALUE,ON_UNSET_VALUE,ON_UNSET_VALUE)
@@ -1641,9 +1641,9 @@ public:
   /*
   Returns:
     The plane equation whose coefficient values are 
-    the negative of the coefficent values in this,
-    provided the coeffient value is valid. Any invalid
-    coefficent values are copied.
+    the negative of the coefficient values in this,
+    provided the coefficient value is valid. Any invalid
+    coefficient values are copied.
   */
   ON_PlaneEquation NegatedPlaneEquation() const;
 
@@ -1831,9 +1831,9 @@ public:
 
   /*
   Description:
-    This function calculates and evalutes points that 
+    This function calculates and evaluates points that 
     would be exactly on the plane if double precision
-    aritmetic were mathematically perfect and returns
+    arithmetic were mathematically perfect and returns
     the largest value of the evaluations.
   */
   double ZeroTolerance() const;
@@ -1898,7 +1898,7 @@ public:
   Parameters:
     bRational - [in]
       False if the points are euclidean (x,y,z)
-      True if the points are homogenous rational (x,y,z,w)
+      True if the points are homogeneous rational (x,y,z,w)
       (x/w,y/w,z/w) is used to evaluate the value.
     point_count - [in]
     point_stride - [in]
@@ -1907,7 +1907,7 @@ public:
       coordinates of points
     stop_value - [in]
       If stop_value is valid and not ON_UNSET_VALUE, then the 
-      evaulation stops if a value > stop_value is found. 
+      evaluation stops if a value > stop_value is found. 
       If stop_value = ON_UNSET_VALUE, then stop_value is ignored.
   Returns:
     Maximum value of the plane equation on the point list.
@@ -1927,7 +1927,7 @@ public:
   Parameters:
     bRational - [in]
       False if the points are euclidean (x,y,z)
-      True if the points are homogenous rational (x,y,z,w)
+      True if the points are homogeneous rational (x,y,z,w)
       (x/w,y/w,z/w) is used to evaluate the value.
     point_count - [in]
     point_stride - [in]
@@ -1936,7 +1936,7 @@ public:
       coordinates of points
     stop_value - [in]
       If stop_value is valid and not ON_UNSET_VALUE, then the 
-      evaulation stops if a value < stop_value is found. 
+      evaluation stops if a value < stop_value is found. 
       If stop_value = ON_UNSET_VALUE, then stop_value is ignored.
   Returns:
     Maximum value of the plane equation on the point list.
@@ -1957,7 +1957,7 @@ public:
   Parameters:
     bRational - [in]
       False if the points are euclidean (x,y,z)
-      True if the points are homogenous rational (x,y,z,w)
+      True if the points are homogeneous rational (x,y,z,w)
       (x/w,y/w,z/w) is used to evaluate the value.
     point_count - [in]
     point_stride - [in]
@@ -1965,7 +1965,7 @@ public:
     points - [in]
       coordinates of points
     stop_value - [in]
-      If stop_value >= 0.0, then the evaulation stops if an
+      If stop_value >= 0.0, then the evaluation stops if an
       absolute value > stop_value is found. If stop_value < 0.0 
       or stop_value is invalid, then stop_value is ignored.
   Returns:
@@ -2269,7 +2269,7 @@ public:
   //   Create 3d point list
   // Parameters:
   //   point_dimension - [in] dimension of input points (2 or 3)
-  //   bRational - [in] true if points are in homogenous rational form
+  //   bRational - [in] true if points are in homogeneous rational form
   //   point_count - [in] number of points
   //   point_stride - [in] number of doubles to skip between points
   //   points - [in] array of point coordinates
@@ -2285,7 +2285,7 @@ public:
   //   Create 3d point list
   // Parameters:
   //   point_dimension - [in] dimension of input points (2 or 3)
-  //   bRational - [in] true if points are in homogenous rational form
+  //   bRational - [in] true if points are in homogeneous rational form
   //   point_count - [in] number of points
   //   point_stride - [in] number of doubles to skip between points
   //   points - [in] array of point coordinates
@@ -2749,8 +2749,8 @@ public:
   /*
   Returns:
     0: no points
-    1: single precison points (float coordinates)
-    2: double precison points (double coordinates)
+    1: single precision points (float coordinates)
+    2: double precision points (double coordinates)
   */
   unsigned int Precision() const;
 
@@ -2773,7 +2773,7 @@ public:
     point_index - [in]
     buffer - [out]
       If point_index is a valid index, the point coordinates
-      are copied to buffer[]; oherwise the buffer coordinates
+      are copied to buffer[]; otherwise the buffer coordinates
       are set to ON_UNSET_VALUE.
       You must insure buffer is not null, has proper alignment
       for storing doubles, and is large enough to store three
@@ -3570,7 +3570,7 @@ private:
   // Number of boundary segments in the polyline
   ON__UINT32 m_boundary_segment_count = 0;
 
-  // In the comments below, H is the horizontal line throught the winding point
+  // In the comments below, H is the horizontal line through the winding point
   // and V is the vertical line through the winding point.
 
   // signed net number of times polyline crosses H to the left of the winding point.
@@ -3589,10 +3589,10 @@ private:
   // A left to right crossing is -1.
   ON__INT32 m_above_crossing_number = 0;
 
-  // 0 != (m_status_bits & 1): left crossing occured
-  // 0 != (m_status_bits & 2): right crossing occured
-  // 0 != (m_status_bits & 4): below crossing occured
-  // 0 != (m_status_bits & 8): above crossing occured
+  // 0 != (m_status_bits & 1): left crossing occurred
+  // 0 != (m_status_bits & 2): right crossing occurred
+  // 0 != (m_status_bits & 4): below crossing occurred
+  // 0 != (m_status_bits & 8): above crossing occurred
   // 0 != (m_status_bits & 16): winding point on horizontal segment
   // 0 != (m_status_bits & 32): winding point on vertical segment
   ON__INT32 m_status_bits = 0;
@@ -3636,7 +3636,7 @@ public:
 	Construction or Initialization
 	Parameters:
 		dom -[in] surface domain
-		closed -[in] closed[0] is true if the surface is closed in u direction (similary for 1 and v)
+		closed -[in] closed[0] is true if the surface is closed in u direction (similarly for 1 and v)
 						Use  ON_IsG1Closed(...) to test for G1-closed surfaces.
 		normband - [in] 0<normband<.5 is a normalized coordinate defining a band on each side of the seam.
 						The bands are {(u,v): dom[0].NormalizedParameterAt(u)< normband } and
@@ -3674,7 +3674,7 @@ we can pull back the curve to the covering space (-inf,inf) x dom[1].
 Parameters
 in - [in] surface parameter points in dom[0] x dom[1]
 dom -[in] surface domain
-closed -[in] closed[0] is true if the surface is closed in u direction (similary for 1 and v)
+closed -[in] closed[0] is true if the surface is closed in u direction (similarly for 1 and v)
 normband - [in] 0<normband<.5 is a normalized coordinate defining a band on each side of the seam.
 The point sequence crosses the seam if consecutive points are in opposite bands
 along the seam.

--- a/opennurbs_pointcloud.h
+++ b/opennurbs_pointcloud.h
@@ -184,7 +184,7 @@ public:
     If the point cloud has some hidden points, then an array
     of length PointCount() is returned and the i-th
     element is true if the i-th vertex is hidden.
-    If no ponts are hidden, nullptr is returned.
+    If no points are hidden, nullptr is returned.
   */
   const bool* HiddenPointArray() const;
 

--- a/opennurbs_pointgrid.cpp
+++ b/opennurbs_pointgrid.cpp
@@ -336,7 +336,7 @@ ON_PointGrid::Transpose()
   int i, j;
   bool rc = false;
   if ( IsValid() ) {
-    // slow stupid way - can be imporved if necessary
+    // slow stupid way - can be improved if necessary
     ON_PointGrid t(m_point_count[1],m_point_count[0]);
     for ( i = 0; i < m_point_count[0]; i++ ) for ( j = 0; j < m_point_count[1]; j++ ) {
       t[j][i] = Point(i,j);

--- a/opennurbs_polycurve.cpp
+++ b/opennurbs_polycurve.cpp
@@ -1309,7 +1309,7 @@ bool ON_PolyCurve::HasGapAt(int segment_index) const
   //
   // June 2019 - sometime in the past decade ON_PolyCurve::HasGap()
   // changed and the test here is different from ON_Curve::IsClosed().
-  // The initial "Note" no longer applies becaue it's no longer
+  // The initial "Note" no longer applies because it's no longer
   // clear why the current ON_PolyCurve::HasGap() elimiated the "b c"
   // test that remained in ON_Curve::IsClosed().
 
@@ -2494,8 +2494,8 @@ bool ON_PolyCurve::Evaluate( // returns false if unable to evaluate
       // 9 November 2010 Dale Lear - ON_TuneupEvaluationParameter fix
       //   When evluation passes through ON_CurveProxy or ON_PolyCurve reparamterization
       //   and the original side parameter was -1 or +1, it is changed to -2 or +2
-      //   to indicate that if t is numerically closed to an end paramter, then
-      //   it should be tuned up to be at the end paramter.
+      //   to indicate that if t is numerically closed to an end parameter, then
+      //   it should be tuned up to be at the end parameter.
       double a = t;
       if ( ON_TuneupEvaluationParameter( side, m_t[segment_index], m_t[segment_index+1], &a) )
       {
@@ -3462,7 +3462,7 @@ bool ON_PolyCurve::Split(
 
 		/* 4 April 2003 Greg Arden		Made the following changes:
 																		1.	Use ParameterSearch() to decide if we should snap domain
-																				boundries to m_t array values.  
+																				boundaries to m_t array values.  
 																		2.  Make sure resulting polycurves have Domain() specified as 
 																				split parameter.   
 																		3.  When true is returned the result passes IsValid().

--- a/opennurbs_polycurve.h
+++ b/opennurbs_polycurve.h
@@ -87,7 +87,7 @@ public:
       If false, gaps are not allowed between polycurve segments.
     text_log - [in] if the object is not valid and text_log
         is not nullptr, then a brief englis description of the
-        reason the object is not valid is appened to the log.
+        reason the object is not valid is appended to the log.
         The information appended to text_log is suitable for 
         low-level debugging purposes by programmers and is 
         not intended to be useful as a high level user 
@@ -644,7 +644,7 @@ public:
   Returns:
     True if a modification was performed and HasGap(gap_index-1)
     returns 0 after the modification.
-    False if no modification was preformed because there
+    False if no modification was performed because there
     was no gap or because one could not be performed.
   Remarks:
     Note that passing the return value from FindNextGap() will 

--- a/opennurbs_polyedgecurve.cpp
+++ b/opennurbs_polyedgecurve.cpp
@@ -431,8 +431,8 @@ bool ON_PolyEdgeCurve::IsClosed(void) const
   if ( !rc && SegmentCount() > 1 )
   {
     // Since the segments that make up a ON_PolyEdgeCurve
-    // cannot have their ends matched (becuase the curves
-    // belong to objects alread in the rhino model), 
+    // cannot have their ends matched (because the curves
+    // belong to objects already in the rhino model), 
     // the IsClosed() test has to tolerate larger gaps
     // in brep topology.
     //

--- a/opennurbs_polyline.h
+++ b/opennurbs_polyline.h
@@ -42,7 +42,7 @@ public:
 
   // Description:
   //   Create a regular polygon circumscribe about a circle.
-  //   The midpoints of the polygon's edges will be tanget to the
+  //   The midpoints of the polygon's edges will be tangent to the
   //   circle.
   // Parameters:
   //   circle - [in]
@@ -190,7 +190,7 @@ public:
   // Parameters:
   //   test_point - [in]
   //   t - [out] parameter for a point on the polyline that
-  //             is closest to test_point.  If mulitple solutions
+  //             is closest to test_point.  If multiple solutions
   //             exist, then the smallest solution is returned.
   // Returns:
   //   true if successful.
@@ -205,7 +205,7 @@ public:
   // Parameters:
   //   test_point - [in]
   //   t - [out] parameter for a point on the polyline that
-  //             is closest to test_point.  If mulitple solutions
+  //             is closest to test_point.  If multiple solutions
   //             exist, then the smallest solution is returned.
   //   segment_index0 - [in] index of segment where search begins
   //   segment_index1 - [in] index of segment where search ends

--- a/opennurbs_polylinecurve.cpp
+++ b/opennurbs_polylinecurve.cpp
@@ -899,8 +899,8 @@ ON_PolylineCurve::Evaluate( // returns false if unable to evaluate
       // 9 November 2010 Dale Lear - ON_TuneupEvaluationParameter fix
       //   When evluation passes through ON_CurveProxy or ON_PolyCurve reparamterization
       //   and the original side parameter was -1 or +1, it is changed to -2 or +2
-      //   to indicate that if t is numerically closed to an end paramter, then
-      //   it should be tuned up to be at the end paramter.
+      //   to indicate that if t is numerically closed to an end parameter, then
+      //   it should be tuned up to be at the end parameter.
       double a = t;
       if ( ON_TuneupEvaluationParameter( side, m_t[segment_index], m_t[segment_index+1], &a) )
       {

--- a/opennurbs_precompiledheader.cpp
+++ b/opennurbs_precompiledheader.cpp
@@ -37,7 +37,7 @@
 #error _M_X64 should be defined for x64 builds
 #endif
 
-// All opennurbs code uses the "offical" _M_X64. Unfortunately, 
+// All opennurbs code uses the "official" _M_X64. Unfortunately, 
 // some Microsoft VC 2005 header files, like float.h do not.
 // The Microsoft compiler should automatically defined both
 // _M_X64 and _M_AMD64 for the WIN64 platform.  If it doesn't,
@@ -80,7 +80,7 @@
 #error ON_COMPILING_OPENNURBS must be defined when compiling opennurbs
 #endif
 
-// CHECK SETTINGS AFTER EVERTHING IS INCLUDED
+// CHECK SETTINGS AFTER EVERYTHING IS INCLUDED
 
 #if defined(_MSC_VER)
 
@@ -89,7 +89,7 @@
 #endif
 
 #if !defined(ON_RUNTIME_WIN)
-// if Microsfot C is used on another platfrom, then lots
+// if Microsfot C is used on another platform, then lots
 // of careful cleaning and checking will be required.
 #error _MSC_VER is defined and ON_RUNTIME_WIN is NOT defined.
 #endif
@@ -113,7 +113,7 @@
 #error _M_X64 should be defined for x64 builds
 #endif
 
-// All opennurbs code uses the "offical" _M_X64. Unfortunately, 
+// All opennurbs code uses the "official" _M_X64. Unfortunately, 
 // some Microsoft VC 2005 header files, like float.h do not.
 // The Microsoft compiler should automatically defined both
 // _M_X64 and _M_AMD64 for the WIN64 platform.  If it doesn't,

--- a/opennurbs_private_wrap_defs.h
+++ b/opennurbs_private_wrap_defs.h
@@ -22,7 +22,7 @@ template <class T>
 ON_PrivateWrap<T>::ON_PrivateWrap()
   : r(*(new(((void*)_buffer))T()))
 {
-  // Use placement new to constuct a T class in the memory located in the _buffer[] member;
+  // Use placement new to construct a T class in the memory located in the _buffer[] member;
 }
 
 template <class T >
@@ -38,7 +38,7 @@ template <class T >
 ON_PrivateWrap< T >::ON_PrivateWrap(const ON_PrivateWrap< T >& src)
   : r(*(new(((void*)_buffer))T(src.r)))
 {
-  // Use in placement new to copy constuct a T class in the memory located in the _buffer[] member;
+  // Use in placement new to copy construct a T class in the memory located in the _buffer[] member;
 }
 
 template <class T >
@@ -53,7 +53,7 @@ template <class T >
 ON_PrivateWrap< T >::ON_PrivateWrap(const ON_PrivateWrap< T >&& src)
   : r(*(new(((void*)_buffer))T(std::move(src.r))))
 {
-  // Use in placement new to rvalue copy constuct a T class in the memory located in the _buffer[] member;
+  // Use in placement new to rvalue copy construct a T class in the memory located in the _buffer[] member;
 }
 
 template <class T >

--- a/opennurbs_progress_reporter.h
+++ b/opennurbs_progress_reporter.h
@@ -38,7 +38,7 @@ public:
       * The callback function should do something that is fast and simple,
         like post a message to a user interface control and return
         immediately.      
-      Paramters passed to the callback function:
+      Parameters passed to the callback function:
         context - [in] 
           the value of callback_context.
         fraction_complete - [in]
@@ -88,7 +88,7 @@ public:
 
   /*
   Description:
-    The caclulation calls ON_ProgressReporter::ReportProgress to report
+    The calculation calls ON_ProgressReporter::ReportProgress to report
     its current progress.  If it is the first call to ReportProgress, 
     or the faction_complete is 1.0, or the fraction_complete has 
     increased a reasonable amount, then the callback function is called.
@@ -118,7 +118,7 @@ public:
 
   /*
   Description:
-    The caclulation calls ON_ProgressReporter::ReportProgress to report
+    The calculation calls ON_ProgressReporter::ReportProgress to report
     its current progress.  If it is the first call to ReportProgress, 
     or the faction_complete is 1.0, or the fraction_complete has 
     increased a reasonable amount, then the callback function is called.
@@ -149,7 +149,7 @@ public:
 
   /*
   Description:
-    The caclulation calls ON_ProgressReporter::ReportProgress to report
+    The calculation calls ON_ProgressReporter::ReportProgress to report
     its current progress.  If it is the first call to ReportProgress, 
     or the faction_complete is 1.0, or the fraction_complete has 
     increased a reasonable amount, then the callback function is called.

--- a/opennurbs_public_examples.h
+++ b/opennurbs_public_examples.h
@@ -1,7 +1,7 @@
 /*
 // Copyright (c) 1993-2017 Robert McNeel & Associates. All rights reserved.
 // OpenNURBS, Rhinoceros, and Rhino3D are registered trademarks of Robert
-// McNeel & Assoicates.
+// McNeel & Associates.
 //
 // THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY.
 // ALL IMPLIED WARRANTIES OF FITNESS FOR ANY PARTICULAR PURPOSE AND OF

--- a/opennurbs_public_version.h
+++ b/opennurbs_public_version.h
@@ -71,7 +71,7 @@
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS) || defined(_WINDOWS_) || defined(__WINDOWS__)
 #if !defined(VS_FF_PRERELEASE)
 // At this time, verrsrc.h does not have protection against multiple includes.
-// Testing for VS_FF_PRERELEASE seems to prevent double incudes and the
+// Testing for VS_FF_PRERELEASE seems to prevent double includes and the
 // redef errors it generates.
 #include "verrsrc.h"
 #endif

--- a/opennurbs_qsort_template.h
+++ b/opennurbs_qsort_template.h
@@ -78,7 +78,7 @@ static void ON_QSORT_SHORT_SORT_FNAME(ON_SORT_TEMPLATE_TYPE *lo, ON_SORT_TEMPLAT
   ON_SORT_TEMPLATE_TYPE *max;
   ON_SORT_TEMPLATE_TYPE tmp;
 
-  /* Note: in assertions below, i and j are alway inside original bound of
+  /* Note: in assertions below, i and j are always inside original bound of
       array to sort. */
 
   while (hi > lo)

--- a/opennurbs_quacksort_template.h
+++ b/opennurbs_quacksort_template.h
@@ -3,7 +3,7 @@
 //
 // Copyright (c) 1993-2011 Robert McNeel & Associates. All rights reserved.
 // OpenNURBS, Rhinoceros, and Rhino3D are registered trademarks of Robert
-// McNeel & Assoicates.
+// McNeel & Associates.
 //
 // THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY.
 // ALL IMPLIED WARRANTIES OF FITNESS FOR ANY PARTICULAR PURPOSE AND OF
@@ -50,7 +50,7 @@ sorting functions.
 #if defined(ON_SORT_TEMPLATE_USE_SWAP)
 #define Swap(a,b) m_swapfunc(a,b,m_width)
 #else
-// use intrinsic assigment
+// use intrinsic assignment
 #define Swap(a,b) ON_SORT_TEMPLATE_TYPE tmp = *a; *a = *b; *b = tmp
 #endif
 

--- a/opennurbs_quaternion.cpp
+++ b/opennurbs_quaternion.cpp
@@ -447,7 +447,7 @@ double ON_Quaternion::Length() const
   //     For small denormalized doubles (positive but smaller
   //     than DBL_MIN), some compilers/FPUs set 1.0/fa to +INF.
   //     Without the ON_DBL_MIN test we end up with
-  //     microscopic quaternions that have infinte norm!
+  //     microscopic quaternions that have infinite norm!
   //
   //     This code is absolutely necessary.  It is a critical
   //     part of the bug fix for RR 11217.

--- a/opennurbs_rand.cpp
+++ b/opennurbs_rand.cpp
@@ -389,7 +389,7 @@ void ON_RandomNumberGenerator::RandomPermutation(void* base, size_t nel, size_t 
   //   number int the range 0 to N-1 when N is not a factor of 2^32.
   //   As usual, this bias is not worth worrying about
   //   unlsess 2^32 / N is smallish.  If you need a random
-  //   permuation of a very large array, look elsewhere.
+  //   permutation of a very large array, look elsewhere.
 
   if ( 0 == sizeof_element % sizeof(ON__UINT64) )
   {

--- a/opennurbs_rand.h
+++ b/opennurbs_rand.h
@@ -176,7 +176,7 @@ public:
 
   /*
   Description:
-    Perform a random permuation on an array.
+    Perform a random permutation on an array.
   Parameters:
     base - [in/out]
       Array of element to permute

--- a/opennurbs_revsurface.cpp
+++ b/opennurbs_revsurface.cpp
@@ -1100,11 +1100,11 @@ bool ON_RevSurface::Split(
     // update bounding boxes
     // if input box was valid, intesect calculated boxes with
     // input box
-    srf_ws->BoundingBox(); // calcluates srf_ws->m_bbox
+    srf_ws->BoundingBox(); // calculates srf_ws->m_bbox
     if ( srf_ws->m_bbox.IsValid() && input_bbox.IsValid() )
       srf_ws->m_bbox.Intersection(input_bbox);
 
-    srf_en->BoundingBox(); // calcluates srf_en->m_bbox
+    srf_en->BoundingBox(); // calculates srf_en->m_bbox
     if ( srf_en->m_bbox.IsValid() && input_bbox.IsValid() )
       srf_en->m_bbox.Intersection(input_bbox);
   }

--- a/opennurbs_revsurface.h
+++ b/opennurbs_revsurface.h
@@ -41,7 +41,7 @@ public:
 
   // The interval m_t specifies the parameterization for the
   // angular parameter; m_t must be an increasing interval.
-  // The parameter m_t[0] corresonds to angle m_angle[0] and 
+  // The parameter m_t[0] corresponds to angle m_angle[0] and 
   // the parameter m_t[1] corresponds to angle m_angle[1].
   // Changing m_t and leaving m_angle unchanged will change the
   // parameterization but not change the locus of the surface.
@@ -276,7 +276,7 @@ public:
               possible to repeatedly call GetNextDiscontinuity
               and step through the discontinuities.
     t1 - [in] (t0 != t1)  If there is a discontinuity at t1 is 
-              will be ingored unless c is a locus discontinuity
+              will be ignored unless c is a locus discontinuity
               type and t1 is at the start or end of the curve.
     t - [out] if a discontinuity is found, then *t reports the
           parameter at the discontinuity.
@@ -287,7 +287,7 @@ public:
         discontinuity found at *t.  A value of 1 means the first 
         derivative or unit tangent was discontinuous.  A value 
         of 2 means the second derivative or curvature was 
-        discontinuous.  A value of 0 means teh curve is not
+        discontinuous.  A value of 0 means the curve is not
         closed, a locus discontinuity test was applied, and
         t1 is at the start of end of the curve.
     cos_angle_tolerance - [in] default = cos(1 degree) Used only

--- a/opennurbs_rtree.cpp
+++ b/opennurbs_rtree.cpp
@@ -386,7 +386,7 @@ bool ON_RTreeIterator::PushChildren(StackElement* sp, bool bFirstChild )
   StackElement* spmax = &m_stack[0] + MAX_STACK;
   const ON_RTreeNode* node = sp->m_node;
   m_sp = 0;
-  // push first leaf coverted by this node onto the stack
+  // push first leaf converted by this node onto the stack
   while( 0 != node && node->m_level >= 0 && node->m_count > 0 )
   {
     if ( 0 == node->m_level )
@@ -2836,7 +2836,7 @@ static void DisconnectBranch(ON_RTreeNode* a_node, int a_index)
 
 
 // Pick a branch.  Pick the one that will need the smallest increase
-// in area to accomodate the new rectangle.  This will result in the
+// in area to accommodate the new rectangle.  This will result in the
 // least total area for the covering rectangles in the current node.
 // In case of a tie, pick the one which was smaller before, to get
 // the best resolution when searching.
@@ -3801,7 +3801,7 @@ bool ON_RTree::Search(
   return SearchBoundedPlaneXYZHelper(m_root, bounded_plane, result);
 }
 
-// Search in an index tree or subtree for all data retangles that overlap the argument rectangle.
+// Search in an index tree or subtree for all data rectangles that overlap the argument rectangle.
 
 static
 bool SearchHelper(const ON_RTreeNode* a_node, ON_RTreeBBox* a_rect, ON_RTreeSearchResultCallback& a_result ) 
@@ -4122,7 +4122,7 @@ bool SearchHelper(const ON_RTreeNode* a_node, const ON_Line* a_line, ON_RTreeSea
 
 
 
-// Search in an index tree or subtree for all data retangles that overlap the argument rectangle.
+// Search in an index tree or subtree for all data rectangles that overlap the argument rectangle.
 
 static bool SearchHelper(const ON_RTreeNode* a_node, const ON_RTreeBBox* a_rect, ON_SimpleArray<ON_RTreeLeaf> &a_result)
 {

--- a/opennurbs_rtree.h
+++ b/opennurbs_rtree.h
@@ -18,7 +18,7 @@
 #define OPENNURBS_RTREE_INC_
 
 /*
-The opennurbs rtree code is a modifed version of the
+The opennurbs rtree code is a modified version of the
 free and unrestricted R-tree implementation obtianed from 
 http://www.superliminal.com/sources/sources.htm
 

--- a/opennurbs_sha1.h
+++ b/opennurbs_sha1.h
@@ -70,7 +70,7 @@ public:
   Description:
     Return a hash of the file system path that is independent 
     of the size of wchar_t, constant across platforms, and 
-    constant across varations in the way the path is formatted.
+    constant across variations in the way the path is formatted.
 
   Parameters:
     path - [in]
@@ -222,9 +222,9 @@ public:
       If true, interior hyphen characters are  parsed.
       Otherwise interior hyphen characters cause parsing to fail.
     bIgnoreInternalSpaces - [in]
-      If true, isolated hyphens are ingored until 40 hex digits are read.
+      If true, isolated hyphens are ignored until 40 hex digits are read.
     bIgnoreInternalHyphens - [in]
-      If true, leading spaces and isolated interior spacess are ingored until 40 hex digits are read.
+      If true, leading spaces and isolated interior spacess are ignored until 40 hex digits are read.
     failure_return_value - [in]
       Value to return if string_to_parse cannot be parsed as 40 hex digits.
   Returns:
@@ -300,7 +300,7 @@ Remarks:
   The SHA-1 hash algorithm is not suitable for cryptographic or security applications.
   The ON_SHA1 class does not "wipe" intermediate results.
 
-  If you have two different seqences of N bytes storing information (lower entropy
+  If you have two different sequences of N bytes storing information (lower entropy
   than a random sequence) are you are not intentionally calculating the information
   to create a SHA-1 hash collision, then the probability that the sequences have
   the same SHA-1 hash is approximately 2^-80 ~ 10^-24.
@@ -545,7 +545,7 @@ public:
     Put another way, you may call Update() zero or more times passing in N1 bytes, 
     call Digest() to get the SHA-1 hash of those N1 bytes, make zero or more additional
     calls to Update() passing in N2 additional bytes, call digest to get the SHA-1 hash
-    of the seqence of (N1 + N2) bytes, and so on.
+    of the sequence of (N1 + N2) bytes, and so on.
   */
   ON_SHA1_Hash Hash() const;
 
@@ -586,7 +586,7 @@ private:
 	ON__UINT32 m_bit_count[2];   // number of bits (lo, hi)
 	ON__UINT32 m_state[5];       // current state
 
-  // chached SHA1 hash - valid if 2 = (2 & m_status_bits)
+  // cached SHA1 hash - valid if 2 = (2 & m_status_bits)
 	mutable ON_SHA1_Hash m_sha1_hash;
 };
 

--- a/opennurbs_sleeplock.h
+++ b/opennurbs_sleeplock.h
@@ -88,7 +88,7 @@ public:
   Description:
     Attempts to get the lock a single time.
   Returns:
-    True if the lock was aquired. False if the lock was not aquired because it was already locked.
+    True if the lock was acquired. False if the lock was not acquired because it was already locked.
   Remarks:
     If GetLockOrReturnFalse() returns true, then you must call ReturnLock() when finished using the protected resource.
     If GetLockOrReturnFalse() returns false, then you must not call ReturnLock().
@@ -107,7 +107,7 @@ public:
       then one attempt is made to get the lock.
     max_wait_msecs - [in]
       maximum number of milliseconds to wait for lock.
-      If max_wait_msecs is 0, then no maximum wating time is used.
+      If max_wait_msecs is 0, then no maximum waiting time is used.
   Returns:
     True if the lock is obtained.
     False if the maximum waiting time expired without getting
@@ -170,7 +170,7 @@ public:
 
   // Used by The ThreadSafe...() functions and for expert users 
   // to use when managing memory controlled by this pool. Best
-  // to ingnore this unless you have a very clear idea of what
+  // to ignore this unless you have a very clear idea of what
   // you are doing, why you are doing it, and when you are doing it.
   // Otherwise, you'll find yourself waiting forever on a nested
   // access request. 

--- a/opennurbs_sphere.h
+++ b/opennurbs_sphere.h
@@ -23,7 +23,7 @@ class ON_CLASS ON_Sphere
 {
 public:
   
-  ON_Plane plane; // equitorial plane
+  ON_Plane plane; // equatorial plane
   double radius;  // > 0
 
   ON_Sphere();

--- a/opennurbs_statics.cpp
+++ b/opennurbs_statics.cpp
@@ -130,7 +130,7 @@ const ON_UUID ON_SubD::FastAndSimpleFacePackingId =
 { 0xc3d8dd54, 0xf8c8, 0x4455, { 0xbb, 0xe, 0x2a, 0x2f, 0x49, 0x88, 0xec, 0x81 } };
 
 // ON_SubD::DefaultFacePackingId must always identitify a built-in face packing
-// algoritm. If a new built-in algorithm is developed that produces generally 
+// algorithm. If a new built-in algorithm is developed that produces generally 
 // better packings and is as fast and reliable as the current default, then
 // ON_SubD::DefaultFacePackingId can be changed. Under no circumstances, should
 // the default be changed to anything that is more than 1.5 times slower than 
@@ -285,7 +285,7 @@ Exceptions:
 If all exponent bits are all 0 (e = 0) and the fraction bits
 are all zero, then the value of the number is zero.
 If all exponent bits are all 0 (e = 0) and at least one fraction
-bits is not zero, then the representaion is "denormalized".
+bits is not zero, then the representation is "denormalized".
 In this case, the float absolute value is 0.f*2^-126 and the
 double absolute value is 0.f*2^-1022.
 If all exponent bits are 1 (float e = 11111111binary = 255decimal
@@ -336,7 +336,7 @@ static double ON__dblinithelper(int i)
   }
   else
   {
-    // this sitation is not handled by this algorithm
+    // this situation is not handled by this algorithm
     // and that is a bug in the algorithm.
     ON_ERROR("CPU has unexpected bit pattern in double 2.0.");
     i7 = 0;
@@ -410,7 +410,7 @@ static float ON__fltinithelper(int i)
   }
   else
   {
-    // this sitation is not handled by this algorithm
+    // this situation is not handled by this algorithm
     // and that is a bug in the algorithm.
     ON_ERROR("CPU has unexpected bit pattern in float 2.0f.");
     i3 = 0;
@@ -929,7 +929,7 @@ static ON_MeshParameters Internal_ON_MeshParameters_Constants(
   // You must also update the mesh parameters file reading code so that settings with old defaults
   // are replaced with setting that have the new defaults AND old defaults get saved in earlier version
   // 3dm files. This requires somebody with a solid understanding of how ON_MeshParameters::Read()/Write()
-  // works, how saving earlier versions of 3dm fiels works, and how reading old version files works.
+  // works, how saving earlier versions of 3dm files works, and how reading old version files works.
 
   switch (selector)
   {
@@ -2631,7 +2631,7 @@ void ON_SubD::SetAutomaticMeshToSubD(
   bool bAutomaticallyCreateSubD
 )
 {
-  // remove possiblity of hacks to use this as a char value
+  // remove possibility of hacks to use this as a char value
   bAutomaticallyCreateSubD = bAutomaticallyCreateSubD ? true : false;
 
   switch (context)
@@ -2798,7 +2798,7 @@ static ON_SubDComponentBase UnsetComponentBaseInit()
 {
   // For efficiency, ON_SubDComponentBase() does not waste time
   // m_cache_subd_P[], m_displacementV[]
-  // but the offical "Unset" ON_SubDComponentBase should have every byte initialized.
+  // but the official "Unset" ON_SubDComponentBase should have every byte initialized.
   ON_SubDComponentBase unset;
   memset(&unset, 0, sizeof(unset));
   return unset;
@@ -2808,7 +2808,7 @@ static ON_SubDVertex EmptyVertexInit()
 {
   // For efficiency, ON_SubDVertex() does not waste time
   // initializing m_limitP[], ..., m_cache_subd_P[], m_displacementV[]
-  // but the offical "Empty" vertex should have every byte initialized.
+  // but the official "Empty" vertex should have every byte initialized.
   ON_SubDVertex empty;
   memset(&empty, 0, sizeof(empty));
   return empty;
@@ -2818,7 +2818,7 @@ static ON_SubDEdge EmptyEdgeInit()
 {
   // For efficiency, ON_SubDEdge() does not waste time
   // initializing m_cache_subd_P[], m_displacementV[]
-  // but the offical "Empty" edge should have every byte initialized.
+  // but the official "Empty" edge should have every byte initialized.
   ON_SubDEdge empty;
   memset(&empty, 0, sizeof(empty));
   return empty;
@@ -2828,7 +2828,7 @@ static ON_SubDFace EmptyFaceInit()
 {
   // For efficiency, ON_SubDFace() does not waste time
   // initializing m_cache_subd_P[], m_displacementV[]
-  // but the offical "Empty" face should have every byte initialized.
+  // but the official "Empty" face should have every byte initialized.
   ON_SubDFace empty;
   memset(&empty, 0, sizeof(empty));
   return empty;

--- a/opennurbs_std_string.h
+++ b/opennurbs_std_string.h
@@ -19,7 +19,7 @@
 
 /*
 When the predecessor of opennurbs was released in 1995, there was
-no robust corss platform support for dynamic string classes.
+no robust cross platform support for dynamic string classes.
 In order to provide robust dynamic string support, openNURBS
 had to implement ON_String and ON_wString.  
 
@@ -110,7 +110,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -126,7 +126,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -149,9 +149,9 @@ Parameters:
     If sEndElement is not null, then *sEndElement points to the
     element of sInputUTF[] were conversion stopped.
 
-    If an error occured and was not masked, then *sEndElement points
+    If an error occurred and was not masked, then *sEndElement points
     to the element of sInputUTF[] where the conversion failed.  
-    If no errors occured or all errors were masked, then 
+    If no errors occurred or all errors were masked, then 
     *sEndElement = sInputUTF + sInputUTF_count or points to
     the zero terminator in sInputUTF[], depending on the input
     value of sInputUTF_count.
@@ -241,7 +241,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -257,7 +257,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -280,9 +280,9 @@ Parameters:
     If sEndElement is not null, then *sEndElement points to the
     element of sInputUTF[] were conversion stopped.
 
-    If an error occured and was not masked, then *sEndElement points
+    If an error occurred and was not masked, then *sEndElement points
     to the element of sInputUTF[] where the conversion failed.  
-    If no errors occured or all errors were masked, then 
+    If no errors occurred or all errors were masked, then 
     *sEndElement = sInputUTF + sInputUTF_count or points to
     the zero terminator in sInputUTF[], depending on the input
     value of sInputUTF_count.
@@ -358,7 +358,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -374,7 +374,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -397,9 +397,9 @@ Parameters:
     If sEndElement is not null, then *sEndElement points to the
     element of sInputUTF[] were conversion stopped.
 
-    If an error occured and was not masked, then *sEndElement points
+    If an error occurred and was not masked, then *sEndElement points
     to the element of sInputUTF[] where the conversion failed.  
-    If no errors occured or all errors were masked, then 
+    If no errors occurred or all errors were masked, then 
     *sEndElement = sInputUTF + sInputUTF_count or points to
     the zero terminator in sInputUTF[], depending on the input
     value of sInputUTF_count.
@@ -480,7 +480,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -496,7 +496,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -519,10 +519,10 @@ Parameters:
     If end_element_index is not null, then *end_element_index is the
     index of the first element in sInputUTF that was not converted. 
 
-    If an error occured and was not masked, then *end_element_index
+    If an error occurred and was not masked, then *end_element_index
     is the index of the element of sInputUTF[] where the conversion
     failed.  
-    If no errors occured or all errors were masked, then 
+    If no errors occurred or all errors were masked, then 
     *end_element_index is the number of elements in sInputUTF[] that
     were converted.
 
@@ -615,7 +615,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -631,7 +631,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -654,10 +654,10 @@ Parameters:
     If end_element_index is not null, then *end_element_index is the
     index of the first element in sInputUTF that was not converted. 
 
-    If an error occured and was not masked, then *end_element_index
+    If an error occurred and was not masked, then *end_element_index
     is the index of the element of sInputUTF[] where the conversion
     failed.  
-    If no errors occured or all errors were masked, then 
+    If no errors occurred or all errors were masked, then 
     *end_element_index is the number of elements in sInputUTF[] that
     were converted.
 
@@ -738,7 +738,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -754,7 +754,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -777,9 +777,9 @@ Parameters:
     If sEndElement is not null, then *sEndElement points to the
     element of sInputUTF[] were conversion stopped.
 
-    If an error occured and was not masked, then *sEndElement points
+    If an error occurred and was not masked, then *sEndElement points
     to the element of sInputUTF[] where the conversion failed.  
-    If no errors occured or all errors were masked, then 
+    If no errors occurred or all errors were masked, then 
     *sEndElement = sInputUTF + sInputUTF_count or points to
     the zero terminator in sInputUTF[], depending on the input
     value of sInputUTF_count.
@@ -874,7 +874,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -890,7 +890,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -913,9 +913,9 @@ Parameters:
     If sEndElement is not null, then *sEndElement points to the
     element of sInputUTF[] were conversion stopped.
 
-    If an error occured and was not masked, then *sEndElement points
+    If an error occurred and was not masked, then *sEndElement points
     to the element of sInputUTF[] where the conversion failed.  
-    If no errors occured or all errors were masked, then 
+    If no errors occurred or all errors were masked, then 
     *sEndElement = sInputUTF + sInputUTF_count or points to
     the zero terminator in sInputUTF[], depending on the input
     value of sInputUTF_count.
@@ -996,7 +996,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -1012,7 +1012,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -1035,9 +1035,9 @@ Parameters:
     If sEndElement is not null, then *sEndElement points to the
     element of sInputUTF[] were conversion stopped.
 
-    If an error occured and was not masked, then *sEndElement points
+    If an error occurred and was not masked, then *sEndElement points
     to the element of sInputUTF[] where the conversion failed.  
-    If no errors occured or all errors were masked, then 
+    If no errors occurred or all errors were masked, then 
     *sEndElement = sInputUTF + sInputUTF_count or points to
     the zero terminator in sInputUTF[], depending on the input
     value of sInputUTF_count.
@@ -1118,7 +1118,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -1134,7 +1134,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -1157,10 +1157,10 @@ Parameters:
     If end_element_index is not null, then *end_element_index is the
     index of the first element in sInputUTF that was not converted. 
 
-    If an error occured and was not masked, then *end_element_index
+    If an error occurred and was not masked, then *end_element_index
     is the index of the element of sInputUTF[] where the conversion
     failed.  
-    If no errors occured or all errors were masked, then 
+    If no errors occurred or all errors were masked, then 
     *end_element_index is the number of elements in sInputUTF[] that
     were converted.
 
@@ -1254,7 +1254,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -1270,7 +1270,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -1293,10 +1293,10 @@ Parameters:
     If end_element_index is not null, then *end_element_index is the
     index of the first element in sInputUTF that was not converted. 
 
-    If an error occured and was not masked, then *end_element_index
+    If an error occurred and was not masked, then *end_element_index
     is the index of the element of sInputUTF[] where the conversion
     failed.  
-    If no errors occured or all errors were masked, then 
+    If no errors occurred or all errors were masked, then 
     *end_element_index is the number of elements in sInputUTF[] that
     were converted.
 

--- a/opennurbs_string.cpp
+++ b/opennurbs_string.cpp
@@ -107,7 +107,7 @@ bool ON_String::IsValid(
     return true;
   for (;;)
   {
-    // These checks attempt to detect cases when the memory used for the header informtion
+    // These checks attempt to detect cases when the memory used for the header information
     // no longer contains valid settings.
     const char* s = m_s;
     if (nullptr == s)
@@ -168,8 +168,8 @@ bool ON_String::IsValid(
     {
       // Because the ON_wString m_s[] array can have internal null elements,
       // the length test has to be enabled in situations where it is certain
-      // that we are in the common situation where m_s[] is a single null teminated 
-      // sting and hdr->string_length is the m_s[] index of the null terminator.
+      // that we are in the common situation where m_s[] is a single null terminated 
+      // string and hdr->string_length is the m_s[] index of the null terminator.
       while (s < s1 && 0 != *s)
         s++;
       if (s != s1)
@@ -182,7 +182,7 @@ bool ON_String::IsValid(
   // prevent imminent and unpredictable crash
   //
   // The empty string is used (as opposed to something like "YIKES - CALL TECH SUPPORT")
-  // becuase anything besides the empty string introduces using heap in a class that
+  // because anything besides the empty string introduces using heap in a class that
   // has been corrupted by some earlier operation.
   const_cast<ON_String*>(this)->m_s = (char*)pEmptyaString;
   // Devs
@@ -1889,7 +1889,7 @@ bool ON::IsDirectory( const char* utf8pathname )
       rc = true;
     }
 #else
-    // this works on Apple and gcc implentations.
+    // this works on Apple and gcc implementations.
     struct stat buf;
     memset(&buf,0,sizeof(buf));
     int stat_errno = stat( utf8pathname, &buf );

--- a/opennurbs_string.h
+++ b/opennurbs_string.h
@@ -374,7 +374,7 @@ public:
   // and copy constructor work fine.
 
   /*
-  Descripton:
+  Description:
     Set check sum values for a buffer
   Parameters:
     size - [in] 
@@ -392,7 +392,7 @@ public:
    );
 
   /*
-  Descripton:
+  Description:
     Set check sum values for a file.
   Parameters:
     fp - [in] pointer to a file opened with ON:FileOpen(...,"rb")
@@ -404,7 +404,7 @@ public:
    );
 
   /*
-  Descripton:
+  Description:
     Set check sum values for a file.
   Parameters:
     filename - [in] name of file.
@@ -418,7 +418,7 @@ public:
   /*
   Description:
     Test buffer to see if it has a matching checksum.
-  Paramters:
+  Parameters:
     size - [in]   size in bytes
     buffer - [in]
   Returns:
@@ -432,7 +432,7 @@ public:
   /*
   Description:
     Test buffer to see if it has a matching checksum.
-  Paramters:
+  Parameters:
     fp - [in] pointer to file opened with ON::OpenFile(...,"rb")
     bSkipTimeCheck - [in] if true, the time of last
        modification is not checked.
@@ -447,7 +447,7 @@ public:
   /*
   Description:
     Test buffer to see if it has a matching checksum.
-  Paramters:
+  Parameters:
     filename - [in]
     bSkipTimeCheck - [in] if true, the time of last
        modification is not checked.
@@ -1312,7 +1312,7 @@ public:
   Remarks:
     1) If the string is UTF-8 encoded and bOrdinalIgnoreCase is true, only
     small latin a - z and capital latin A - Z are considered equal.  It is
-    imposible to ignore case for any other values in an ordinal compare.
+    impossible to ignore case for any other values in an ordinal compare.
 
     2) If you are comparing file system paths, you should use ComparePath().
 
@@ -1340,7 +1340,7 @@ public:
   Remarks:
     1) If the string is UTF-8 encoded and bOrdinalIgnoreCase is true, only
     small latin a - z and capital latin A - Z are considered equal.  It is
-    imposible to ignore case for any other values in a UTF-8 ordinal compare.
+    impossible to ignore case for any other values in a UTF-8 ordinal compare.
 
     2) If you are comparing file system paths, you should use ComparePath().
 
@@ -1373,7 +1373,7 @@ public:
   Remarks:
     1) If the string is UTF-8 encoded and bOrdinalIgnoreCase is true, only
     small latin a - z and capital latin A - Z are considered equal.  It is
-    imposible to ignore case for any other values in a UTF-8 ordinal compare.
+    impossible to ignore case for any other values in a UTF-8 ordinal compare.
 
     2) If you are comparing file system paths, you should use ComparePath().
 
@@ -1508,26 +1508,26 @@ public:
   // Description:
   //   Simple case sensitive wildcard matching. A question mark (?) in the
   //   pattern matches a single character.  An asterisk (*) in the pattern
-  //   mathes zero or more occurances of any character.
+  //   matches zero or more occurrences of any character.
   //
   // Parameters:
   //   pattern - [in] pattern string where ? and * are wild cards.
   //
   // Returns:
-  //   true if the string mathes the wild card pattern.
+  //   true if the string matches the wild card pattern.
 	bool WildCardMatch( const char* ) const;
 	bool WildCardMatch( const unsigned char* ) const;
 
   // Description:
   //   Simple case insensitive wildcard matching. A question mark (?) in the
   //   pattern matches a single character.  An asterisk (*) in the pattern
-  //   mathes zero or more occurances of any character.
+  //   matches zero or more occurrences of any character.
   //
   // Parameters:
   //   pattern - [in] pattern string where ? and * are wild cards.
   //
   // Returns:
-  //   true if the string mathes the wild card pattern.
+  //   true if the string matches the wild card pattern.
 	bool WildCardMatchNoCase( const char* ) const;
 	bool WildCardMatchNoCase( const unsigned char* ) const;
 
@@ -1809,11 +1809,11 @@ public:
   Parameters:
     format - [in]
       Format control.  
-      Positional paramters of the form %N$x where N >= 1 and x
+      Positional parameters of the form %N$x where N >= 1 and x
       is the standard format specification are supported.
       Avoid using %S (capital S).  See the Remarks for details.
     ... - [in]
-      arguments for replacable items in the format string.
+      arguments for replaceable items in the format string.
   Returns:
     True if successful.
     False if the string is too long or the format string is not valid.
@@ -1823,7 +1823,7 @@ public:
     ON_Locale::InvariantCulture::LocalePtr().
 
     The way Windows handles the %S (capital S) format parameter depends on locale
-    and code page settings.  It is strongly reccommended that you never use %S to
+    and code page settings.  It is strongly recommended that you never use %S to
     include any string that may possibly contain elements with values > 127.
     The following examples illustrate a way to predictably use UTF-8 and wchar_t
     parameters in buffers of the other element type.
@@ -1871,7 +1871,7 @@ public:
   Description:
     A platform independent, secure, culture invariant way to format a char string. 
     This function is provide to be used when it is critical that 
-    the formatting be platform independent, secure and culture invarient.
+    the formatting be platform independent, secure and culture invariant.
   Parameters:
     buffer - [out] 
       not null
@@ -1890,7 +1890,7 @@ public:
       If buffer is not null and buffer_capacity > 0, then buffer[0] = 0 and buffer[buffer_capacity-1] = 0;
   Remarks:
     The way Windows handles the %S (capital S) format parameter depends on locale
-    and code page settings.  It is strongly reccommended that you never use %S to
+    and code page settings.  It is strongly recommended that you never use %S to
     include any string that may possibly contain elements with values > 127.  
     The following examples illustrate a way to predictably use UTF-8 and wchar_t 
     parameters in buffers of the other element type.
@@ -3040,7 +3040,7 @@ public:
   Remarks:
     1) If the string is UTF-8 encoded and bOrdinalIgnoreCase is true, only
     small latin a - z and capital latin A - Z are considered equal.  It is
-    imposible to ignore case for any other values in an ordinal compare.
+    impossible to ignore case for any other values in an ordinal compare.
 
     2) If you are comparing file system paths, you should use ComparePath().
 
@@ -3069,7 +3069,7 @@ public:
   Remarks:
     1) If the string is UTF-8 encoded and bOrdinalIgnoreCase is true, only
     small latin a - z and capital latin A - Z are considered equal.  It is
-    imposible to ignore case for any other values in an ordinal compare.
+    impossible to ignore case for any other values in an ordinal compare.
 
     2) If you are comparing file system paths, you should use ComparePath().
 
@@ -3098,7 +3098,7 @@ public:
   Remarks:
     1) If the string is UTF-8 encoded and bOrdinalIgnoreCase is true, only
     small latin a - z and capital latin A - Z are considered equal.  It is
-    imposible to ignore case for any other values in an ordinal compare.
+    impossible to ignore case for any other values in an ordinal compare.
 
     2) If you are comparing file system paths, you should use ComparePath().
 
@@ -3232,25 +3232,25 @@ public:
   // Description:
   //   Simple case sensitive wildcard matching. A question mark (?) in the
   //   pattern matches a single character.  An asterisk (*) in the pattern
-  //   mathes zero or more occurances of any character.
+  //   matches zero or more occurrences of any character.
   //
   // Parameters:
   //   pattern - [in] pattern string where ? and * are wild cards.
   //
   // Returns:
-  //   true if the string mathes the wild card pattern.
+  //   true if the string matches the wild card pattern.
 	bool WildCardMatch( const wchar_t* ) const;
 
   // Description:
   //   Simple case insensitive wildcard matching. A question mark (?) in the
   //   pattern matches a single character.  An asterisk (*) in the pattern
-  //   mathes zero or more occurances of any character.
+  //   matches zero or more occurrences of any character.
   //
   // Parameters:
   //   pattern - [in] pattern string where ? and * are wild cards.
   //
   // Returns:
-  //   true if the string mathes the wild card pattern.
+  //   true if the string matches the wild card pattern.
 	bool WildCardMatchNoCase( const wchar_t* ) const;
 
   /*
@@ -3276,7 +3276,7 @@ public:
   /*
   Description:
     Replaces all %xx where xx a two digit hexadecimal number,
-    with a single character. Returns false if the orginal
+    with a single character. Returns false if the original
     string contained 
   */
   bool UrlDecode();
@@ -3484,7 +3484,7 @@ public:
 
   /*
   Returns:
-    A platform independed SHA-1 of the string content. Independent of platform endian or platform wide string UTF encoding.
+    A platform independent SHA-1 of the string content. Independent of platform endian or platform wide string UTF encoding.
   */
   const ON_SHA1_Hash ContentHash(
     ON_StringMapOrdinalType mapping
@@ -3585,7 +3585,7 @@ public:
 
   /*
   Description:
-    Parse an xml encoded unicde code point.
+    Parse an xml encoded unicode code point.
     &#nnnn; (nnnn = any number of decimal digits)
     &#xhhhh; (hhhh = any muber of hexadecimal digits)
   Parameters:
@@ -3678,7 +3678,7 @@ public:
     numerator - [out]
     denominator - [out]
   Returns:
-    If a vulgar fraction was succesfully parsed, the a pointer to the first character
+    If a vulgar fraction was successfully parsed, the a pointer to the first character
     after the vulgar fraction is returned. Otherwise nullptr is returned.
   */
   static const wchar_t* ParseVulgarFraction(
@@ -4134,11 +4134,11 @@ public:
   Parameters:
     format - [in]
       Format control.
-      Positional paramters of the form %N$x where N >= 1 and x
+      Positional parameters of the form %N$x where N >= 1 and x
       is the standard format specification are supported.
       Avoid using %S (capital S).  See the Remarks for details.
     ... - [in]
-      arguments for replacable items in the format string.
+      arguments for replaceable items in the format string.
   Returns:
     True if successful.
     False if the string is too long or the format string is not valid.
@@ -4148,7 +4148,7 @@ public:
     ON_Locale::InvariantCulture::LocalePtr().
 
     The way Windows handles the %S (capital S) format parameter depends on locale
-    and code page settings.  It is strongly reccommended that you never use %S to
+    and code page settings.  It is strongly recommended that you never use %S to
     include any string that may possibly contain elements with values > 127.
     The following examples illustrate a way to predictably use UTF-8 and wchar_t
     parameters in buffers of the other element type.
@@ -4187,7 +4187,7 @@ public:
     A platform independent, secure, culture invariant way to format a wchar_t string
     with support for positional format parameters.
     This function is provide to be used when it is critical that 
-    the formatting be platform independent, secure and culture invarient.
+    the formatting be platform independent, secure and culture invariant.
   Parameters:
     buffer - [out] 
       not null
@@ -4206,7 +4206,7 @@ public:
       If buffer is not null and buffer_capacity > 0, then buffer[0] = 0 and buffer[buffer_capacity-1] = 0;
   Remarks:
     The way Windows handles the %S (capital S) format parameter depends on locale
-    and code page settings.  It is strongly reccommended that you never use %S to
+    and code page settings.  It is strongly recommended that you never use %S to
     include any string that may possibly contain elements with values > 127.  
     The following examples illustrate a way to predictably use UTF-8 and wchar_t 
     parameters in buffers of the other element type.
@@ -4469,7 +4469,7 @@ public:
 
   /*
   Description:
-    Expert user funtion to reserve and gain access to string memory.
+    Expert user function to reserve and gain access to string memory.
   Parameters:
     capacity - [in]
       If capacity > ON_String::MaximumStringLength, then nullptr is returned.

--- a/opennurbs_string_compare.cpp
+++ b/opennurbs_string_compare.cpp
@@ -61,7 +61,7 @@ static ON__UINT32 MapCodePointOrdinal(
   )
 {
   // Converts ordinal "char" and "wchar_t" element values in the
-  // range 0x00 to maximum_singleton_value to "ingore case" ordinal equivalents.
+  // range 0x00 to maximum_singleton_value to "ignore case" ordinal equivalents.
   // The returned value is always <= input value.
   //
   // This is NOT linguistic and NOT culture invariant.
@@ -493,7 +493,7 @@ static unsigned int OrdinalUnsignedToIgnoreCase(
 {
   // RH-41224
   // map A -> a, ..., Z -> z so underbar is before any "letter".
-  // The preserves the behavoir of Rhino component name sorting
+  // The preserves the behavior of Rhino component name sorting
   // that used "ancient" C runtime ASCII sorts.
   const ON_StringMapOrdinalType map_type
     = ( c <= 0x7A && c >= 0x41 && maximum_singleton_value >= 0x7A )

--- a/opennurbs_string_format.cpp
+++ b/opennurbs_string_format.cpp
@@ -234,7 +234,7 @@ const ON_String ON_String::ApproximateFromNumber(
     // thate are 300 digits long when a 1e300 comes by.
     if (ON_String::FormatIntoBuffer(buffer, sizeof(buffer) / sizeof(buffer[0]), "%f", d) > 0)
       return ON_String(buffer);
-    // It may be that 64 elements were not enought for %f format if the "reasonable range"
+    // It may be that 64 elements were not enough for %f format if the "reasonable range"
     // test is not good enough.  We try again with "%g".
   }
   if (ON_String::FormatIntoBuffer(buffer, sizeof(buffer) / sizeof(buffer[0]), "%g", d) > 0)
@@ -337,7 +337,7 @@ const ON_wString ON_wString::ApproximateFromNumber(
     // thate are 300 digits long when a 1e300 comes by.
     if (ON_wString::FormatIntoBuffer(buffer, sizeof(buffer) / sizeof(buffer[0]), L"%f", d) > 0)
       return ON_String(buffer);
-    // It may be that 64 elements were not enought for %f format if the "reasonable range"
+    // It may be that 64 elements were not enough for %f format if the "reasonable range"
     // test is not good enough.  We try again with "%g".
   }
   if (ON_wString::FormatIntoBuffer(buffer, sizeof(buffer) / sizeof(buffer[0]), L"%g", d) > 0)

--- a/opennurbs_string_value.h
+++ b/opennurbs_string_value.h
@@ -465,7 +465,7 @@ public:
 
 #pragma region RH_C_SHARED_ENUM [ON_ScaleValue::ScaleStringFormat] [Rhino.ScaleValue.ScaleStringFormat] [nested:byte]
   /// <summary>
-  /// Specifies prefered formats for automatically
+  /// Specifies preferred formats for automatically
   /// created string descriptions of a scale value.
   /// </summary>
   enum class ScaleStringFormat : unsigned char
@@ -617,7 +617,7 @@ public:
   /*
   Returns:
     A dimensionless scale factor.
-    The word "dimensionless" is critical. Differneces in left and right
+    The word "dimensionless" is critical. Differences in left and right
     side unit systems are accounted for in the returned value.
   Remarks:
     LeftToRightScale() = 1.0/RightToLeftScale()
@@ -648,7 +648,7 @@ public:
   /*
   Returns:
     A dimensionless scale factor.
-    The word "dimensionless" is critical. Differneces in left and right
+    The word "dimensionless" is critical. Differences in left and right
     side unit systems are accounted for in the returned value.
   Remarks:
     RightToLeftScale() = 1.0/LeftToRightScale()

--- a/opennurbs_subd.cpp
+++ b/opennurbs_subd.cpp
@@ -1610,7 +1610,7 @@ class ON_SubDComponentBase* ON_SubDComponentPtr::ComponentBase() const
     // This is in a controlled setting inside functions like ON_SubDArchiveIdMap::ConvertArchiveIdToRuntimeSymmetrySetNextPtr().
     // All public level SDK code can safely assume the returned value is a true pointer.
     // It does mean that you cannot "validate" the value returned here
-    // using some contraint on what you feel is a reasonable true pointer value.
+    // using some constraint on what you feel is a reasonable true pointer value.
     return ((class ON_SubDComponentBase*)ON_SUBD_COMPONENT_POINTER(m_ptr));
     break;
   }
@@ -1949,7 +1949,7 @@ const ON_SubDComponentPoint ON_SubDComponentPoint::BestPickPoint(
     && ((type_bias >= 0) ? Internal_FirstIsPartOfSecond(A, B) : Internal_FirstIsPartOfSecond(B, A))
     )
   {
-    // A point pick is occuring and best is a vertex on an edge/face or best is an edge on a face.
+    // A point pick is occurring and best is a vertex on an edge/face or best is an edge on a face.
     // Bias towards the vertex/edge.
     // Users can pick the middle of an edge/face if they want the "bigger" component.
     ON_SubDComponentPoint best = (type_bias >= 0) ? A : B;
@@ -5015,7 +5015,7 @@ ON_SubDVertexTag ON_SubDVertex::SuggestedVertexTag(
       return ON_SubDVertexTag::Smooth;
     if (bReturnBestGuessWhenInvalid)
     {
-      // can occure when there is a nullptr edge
+      // can occur when there is a nullptr edge
       best_guess_tag = ON_SubDVertexTag::Smooth;
     }
     break;
@@ -5510,7 +5510,7 @@ const ON_SubDHash ON_SubDimple::SubDHash(
     && face_count == h->FaceCount()
     )
   {
-    // The chache hash values are up to date (or should be).
+    // The cache hash values are up to date (or should be).
     // If h is out of date, something somewhere modified the SubD components and 
     // failed to change the GeometryContentSerialNumber(). 
     // All C++ SDK opennurbs code changes gsn after modifying SubD geometry (or it's a bug that should be fixed).
@@ -6793,7 +6793,7 @@ unsigned int ON_SubD::DumpTopology(
 
     if (false == text_log.IsTextHash())
     {
-      // runtime settings most recentltly used to set fragmant texture coordinates.
+      // runtime settings most recentltly used to set fragment texture coordinates.
       const ON_SHA1_Hash frament_texture_settings_hash = this->FragmentTextureCoordinatesTextureSettingsHash();
       text_log.Print(L"FragmentTextureCoordinatesTextureSettingsHash() = ");
       if (subd_texture_settings_hash == frament_texture_settings_hash)
@@ -6824,7 +6824,7 @@ unsigned int ON_SubD::DumpTopology(
     const size_t sizeof_frags = this->SizeOfAllMeshFragments();
     text_log.PrintString(ON_wString(L"Mesh fragments = ") + ON_wString::ToMemorySize(sizeof_frags) + ON_wString(L".\n"));
     const size_t sizeof_frags_waste = this->SizeOfUnusedMeshFragments();
-    text_log.PrintString(ON_wString(L"Reserved but ununsed = ")
+    text_log.PrintString(ON_wString(L"Reserved but unused = ")
       + Internal_DescribeWaste(sizeof_frags_waste,sizeof_subd)
       + ON_wString(L".\n"));
   }
@@ -10168,7 +10168,7 @@ bool ON_SubDFace::EvaluateCatmullClarkSubdivisionPoint(double subdivision_point[
   // Use faster code for the case when the face is a quad.
   // Since this is a Catmull-Clark subdivision scheme, this
   // case is the most common by far and code that gives quads
-  // special treatment will run noticably faster.
+  // special treatment will run noticeably faster.
   e_ptr = edge_ptr[0].m_ptr;
   e = ON_SUBD_EDGE_POINTER(e_ptr);
   if ( nullptr == e || nullptr == e->m_vertex[0] || nullptr == e->m_vertex[1] )
@@ -12345,7 +12345,7 @@ bool ON_SubDimple::LocalSubdivide(
   ON_SimpleArray<ON_SubDFace*> faces(face_count);
   ON_SimpleArray<ON_3dPoint> face_points(face_count);
 
-  // this subd is being modifed.
+  // this subd is being modified.
   ChangeGeometryContentSerialNumber( false);
 
   for (const ON_SubDFace* f0 = level0.m_face[0]; nullptr != f0; f0 = f0->m_next_face)
@@ -13043,14 +13043,14 @@ static bool Internal_EdgesAreConsecutive(
     const double miniscule_distance_tolerance = ON_ZERO_TOLERANCE;
     if (h <= miniscule_distance_tolerance && !(distance_tolerance >= 0.0 && distance_tolerance < miniscule_distance_tolerance))
     {
-      // skip parameter tests for miniscule h.
+      // skip parameter tests for minuscule h.
       return true;
     }
 
     const double miniscule_maximum_aspect = 1e-4;
     if (h <= miniscule_maximum_aspect * d && !(maximum_aspect >= 0.0 && maximum_aspect < miniscule_maximum_aspect))
     {
-      // skip parameter tests for miniscule h/d.
+      // skip parameter tests for minuscule h/d.
       return true;
     }
 
@@ -14011,7 +14011,7 @@ const ON_SubDEdge* ON_SubDimple::SplitFace(
     new_edge_count[0] = fvi0 - fvi1 + 1;
     new_edge_count[1] = (edge_count + 2) - new_edge_count[0];
   }
-  // make sure each side is at least a triangle and no overflows occured
+  // make sure each side is at least a triangle and no overflows occurred
   if (new_edge_count[0] < 3 || new_edge_count[0] >= edge_count)
     return ON_SUBD_RETURN_ERROR(nullptr);
   if (new_edge_count[1] < 3 || new_edge_count[1] >= edge_count)
@@ -15009,7 +15009,7 @@ bool ON_SubD::DeleteComponentsForExperts(
       cptr.ClearStates(ON_ComponentStatus::Damaged);
   }
 
-  // Set the status of every compoent in cptr_list[] to ON_ComponentStatus::AllSet.
+  // Set the status of every component in cptr_list[] to ON_ComponentStatus::AllSet.
   // If that component is a vertex, set the status of every edge and face that
   // touch the vertex to ON_ComponentStatus::AllSet.
   // If that component is an edge, set the status of every face that
@@ -17640,7 +17640,7 @@ static bool Internal_SetSideGroupIds(ON_SimpleArray<ON_Internal_ExtrudedEdge>& n
     if (false == new_sides[i].SetSideGroupId(side_group_id))
       continue;
 
-    // propogate side_group_id through all touching components
+    // propagate side_group_id through all touching components
     unsigned j0 = i + 1;
     for (bool bContinue = true; bContinue; /*empty iterator*/)
     {      
@@ -17886,7 +17886,7 @@ unsigned int ON_SubD::Internal_ExtrudeComponents(
       }
 
       // Partially setting the topology connections here reduces the number of binary searches by about half.
-      // The scecond paramter is false because the sorting of extruded_vertices[] will change the memory
+      // The scecond parameter is false because the sorting of extruded_vertices[] will change the memory
       // location where extruded_vertex is stored.
       if (false == extruded_vertex.AddExtrudedEdgeReference(&extruded_edge, false))
         return 0;
@@ -18255,7 +18255,7 @@ unsigned int ON_SubD::SetVertexTags(
         }
         else
         {
-          // dont' attempt change - further refinement may be needed here
+          // don't attempt change - further refinement may be needed here
           continue;
         }
       }
@@ -18304,7 +18304,7 @@ unsigned int ON_SubD::SetVertexTags(
   // This for loop is used when new vertex_tag is ON_SubDVertexTag::Crease.
   for (int pass = 0; pass < 2 && false == bUpdateTags; pass++)
   {
-    // More careful analysis is neeeded to accurately mark smooth edges that will become creases
+    // More careful analysis is needed to accurately mark smooth edges that will become creases
     ON_SubDEdgeIterator eit(*this);
     for (const ON_SubDEdge* edge = eit.FirstEdge(); nullptr != edge; edge = eit.NextEdge())
     {
@@ -21366,7 +21366,7 @@ ON_SubDFace* ON_SubD::FindOrAddFace(
     return ON_SUBD_RETURN_ERROR(nullptr);
 
 
-  // Mkae sure v[] has vertex_count unique non-null vertices.
+  // Make sure v[] has vertex_count unique non-null vertices.
   for (unsigned i = 0; i < vertex_count; ++i)
   {
     if (nullptr == face_vertices[i])

--- a/opennurbs_subd.h
+++ b/opennurbs_subd.h
@@ -139,7 +139,7 @@ enum class ON_SubDGetControlNetMeshPriority : unsigned char
   /// includes SubD texture coordinate information.
   /// Use this option when the mesh will be used to create an image of the
   /// SubD control net that relies on texture coordinates. SubD interior edge
-  /// crease inforation cannot be recovered from the mesh. Most applications will 
+  /// crease information cannot be recovered from the mesh. Most applications will 
   /// not be able to use the mesh to recreate a Catmull-Clark subdivision surface.
   ///</summary>
   TextureCoordinates = 1
@@ -162,7 +162,7 @@ enum class ON_SubDTextureCoordinateType : unsigned char
   Unpacked = 1,
 
   ///<summary>
-  /// The face's pack rect is used to set fragment texture coordintes.
+  /// The face's pack rect is used to set fragment texture coordinates.
   /// When possible, adjacent quads with the same ON_SubDFace::PackId() value are assigned adjacent 
   /// rectangles in texture space.
   ///</summary>
@@ -185,7 +185,7 @@ enum class ON_SubDTextureCoordinateType : unsigned char
   FromFaceTexturePoints = 6,
 
   ///<summary>
-  /// Texture coordinates are set from an ON_TextureMapping and transformation specificed
+  /// Texture coordinates are set from an ON_TextureMapping and transformation specified
   /// by ON_SubD::TextureMappingTag(). In all other cases, ON_SubD::TextureMappingTag()
   /// can be set, but is ignored.
   ///</summary>
@@ -368,11 +368,11 @@ public:
   /// </summary>
   static const ON_SubDHash Empty;
 
-  // Saves the counts and hashs of the specified type
+  // Saves the counts and hashes of the specified type
 
 
   /// <summary>
-  /// Saves the counts and hashs of the specified type.
+  /// Saves the counts and hashes of the specified type.
   /// </summary>
   /// <param name="hash_type"></param>
   /// <param name="subd"></param>
@@ -674,7 +674,7 @@ public:
   /*
   Returns:
     True if this vertex is active in its parent subd or other
-    relevent context.
+    relevant context.
   Remarks:
     When a component is in use, IsActive() = true. 
     If was used and then deleted, IsActive() is false.
@@ -713,7 +713,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   */
   bool Mark() const;
 
@@ -724,7 +724,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -737,7 +737,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -752,7 +752,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -807,7 +807,7 @@ public:
   /*
   Returns:
     True if this edge is active in its parent subd or other
-    relevent context.
+    relevant context.
   Remarks:
     When a component is in use, IsActive() = true. 
     If was used and then deleted, IsActive() is false.
@@ -1009,7 +1009,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   */
   bool Mark() const;
 
@@ -1020,7 +1020,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -1033,7 +1033,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -1048,7 +1048,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -1086,7 +1086,7 @@ public:
   /*
   Returns:
     True if this face is active in its parent subd or other
-    relevent context.
+    relevant context.
   Remarks:
     When a component is in use, IsActive() = true. 
     If was used and then deleted, IsActive() is false.
@@ -1146,7 +1146,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   */
   bool Mark() const;
 
@@ -1157,7 +1157,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -1170,7 +1170,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -1185,7 +1185,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -1286,7 +1286,7 @@ public:
   /*
   Returns:
     True if this component is active in its parent subd or other
-    relevent context.
+    relevant context.
   Remarks:
     When a component is in use, IsActive() = true. 
     If was used and then deleted, IsActive() is false.
@@ -1297,7 +1297,7 @@ public:
   Returns:
     True if this component is marked as a primary motif component.
   Remarks:
-    You must use ON_SubD SymmetrySet memeber functions to get symmetry set contents.
+    You must use ON_SubD SymmetrySet member functions to get symmetry set contents.
   */
   bool IsSymmetrySetPrimaryMotif() const;
 
@@ -1305,7 +1305,7 @@ public:
   Returns:
     True if this component is marked being in a symmetry set.
   Remarks:
-    You must use ON_SubD SymmetrySet memeber functions to get symmetry set contents.
+    You must use ON_SubD SymmetrySet member functions to get symmetry set contents.
   */
   bool InSymmetrySet() const;
 
@@ -1355,7 +1355,7 @@ public:
     The use of this value varies depending on the context.
     Frequently, 0 means the referenced component is being used with its
     natural orientation and 1 means the referenced component is being used
-    with the reverse of its natrual oreientation.
+    with the reverse of its natural oreientation.
   */
   ON__UINT_PTR ComponentDirection() const;
 
@@ -1427,7 +1427,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   */
   bool Mark() const;
 
@@ -1438,7 +1438,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -1451,7 +1451,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -1466,7 +1466,7 @@ public:
     SubD components have a mutable runtime  mark that can be used 
     in any context where a single thread cares about the marks.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -2224,7 +2224,7 @@ public:
      s_capacity
        wchar_t element capacity of the string buffer
   Returns:
-    nullptr if ther is not enough room in the buffer.
+    nullptr if there is not enough room in the buffer.
     Otherwise a pointer to the null terminator of the returned string.
   Remarks
     The returned string will be "0" for a zero sector id, "X" for an invalid sector id, 
@@ -2429,7 +2429,7 @@ public:
     This is useful when quick compare and sorting of regions is required,
     m_subdivision_count < 256, m_index[0] < 256, m_index[1] < 4, ..., m_index[m_subdivision_count] < 4
     Regions of N-gons with N < 256 and regions of edges
-    satisify these condition when m_subdivision_count < 256 
+    satisfy these condition when m_subdivision_count < 256 
     (which is always in real world situations).
   */
   ON__UINT32 ToCompressedRegionIndex() const;
@@ -2977,7 +2977,7 @@ public:
 
   /*
   Description:
-    Change the geoemtry content serial number to indicate something affecting
+    Change the geometry content serial number to indicate something affecting
     the geometric shape of the subd has changed. This includes topologial changes,
     vertex and edge tag changes, and changes to vertex control net locations.
   Parameters:
@@ -3030,7 +3030,7 @@ public:
    bForceUpdate - [in]
      When in doubt pass false.
      The SubD hashes are mutable and cached. When code properly manages GeometryContentSerialNumber(),
-     then SubDHash(hash_type,false) will alwasys return the correct answer. This is the expected behavior.
+     then SubDHash(hash_type,false) will alwayss return the correct answer. This is the expected behavior.
      If code directly modifies SubD components and fails to call ChangeGeometryContentSerialNumberForExperts(),
      then it is possible a stale hash will be returned. Setting bForceUpdate = true forces the SHA1
      values to be recalculated from scratch. For extremely large SubDs, this recalculation can be time consuming.
@@ -3113,7 +3113,7 @@ public:
 
 
   /*
-  Paramters:
+  Parameters:
     vertex_tag - [in]
     bVerbose - [in]
       If verbose, the tag name is preceded with "ON_SubDVertexTag::".
@@ -3160,7 +3160,7 @@ public:
 
 
   /*
-  Paramters:
+  Parameters:
     edge_tag - [in]
     bVerbose - [in]
       If verbose, the tag name is preceded with "ON_SubDEdgeTag::".
@@ -3310,8 +3310,8 @@ public:
       component_ring[component_count-1] = last face
 
   Example:
-    unsinged int component_ring_count = GetVertexComponentRing(vit,component_ring);
-    unsinged int N = component_ring_count/2; // number of edges in ring
+    unsigned int component_ring_count = GetVertexComponentRing(vit,component_ring);
+    unsigned int N = component_ring_count/2; // number of edges in ring
     const bool bSectorHasCreaseBoundary = (0 == (component_ring_count % 2));
   */
   static unsigned int GetSectorComponentRing(
@@ -3350,8 +3350,8 @@ public:
       component_ring[component_count-1] = last face
 
   Example:
-    unsinged int component_ring_count = GetVertexComponentRing(vit,component_ring);
-    unsinged int N = component_ring_count/2; // number of edges in ring
+    unsigned int component_ring_count = GetVertexComponentRing(vit,component_ring);
+    unsigned int N = component_ring_count/2; // number of edges in ring
     const bool bSectorHasCreaseBoundary = (0 == (component_ring_count % 2));
   */
   static unsigned int GetSectorComponentRing(
@@ -3662,7 +3662,7 @@ public:
   Description:
     This is a debugging too used to study how efficiently SubDs are using memory.
   Returns:
-    Total operating system heap (in bytes) used by this SubD's ON_FixedSizePools, inlcude the mesh fragments pool.
+    Total operating system heap (in bytes) used by this SubD's ON_FixedSizePools, include the mesh fragments pool.
   Remarks:
     SizeOfAllElements() = SizeOfActiveElements() + SizeOfUnusedElements().
   */
@@ -3871,7 +3871,7 @@ public:
 public:
 #pragma region RH_C_SHARED_ENUM [ON_SubD::AutomaticMeshToSubDContext] [Rhino.Geometry.SubDAutomaticMeshToSubDContext] [byte]
   /// <summary>
-  /// ON_SubD::AutomaticMeshToSubDContext indentifies a context where meshes can automatically
+  /// ON_SubD::AutomaticMeshToSubDContext identifies a context where meshes can automatically
   /// be converted to subds.
   /// </summary>
   enum class AutomaticMeshToSubDContext : unsigned char
@@ -4116,7 +4116,7 @@ public:
   /*
   Description:
     Remove subdivision levels
-  Paramters:
+  Parameters:
     max_level_index - [in] 
       Remove all levels after max_level_index
   Returns:
@@ -4129,7 +4129,7 @@ public:
   /*
   Description:
     Remove subdivision levels
-  Paramters:
+  Parameters:
     min_level_index - [in] 
       Remove all levels before min_level_index
   Returns:
@@ -4616,7 +4616,7 @@ public:
   ///*
   //Description:
   //  The ON__INT_PTRs in the tree are const ON_SubDComponentPtrs.
-  //  The bounding boxs are based on the subd
+  //  The bounding box are based on the subd
   //*/
   //ON_RTreeRef ControlNetComponentTree(
   //  bool bIncludeVertices,
@@ -4761,7 +4761,7 @@ public:
   /*
   Description:
     Split and edge.
-    The input edge is modifed to terminate at the input vertex.
+    The input edge is modified to terminate at the input vertex.
     The new edge begins at the input vertex and ends at the final vertex
     of the original input edge.
   edge - [in]
@@ -4843,7 +4843,7 @@ public:
       If true, face and new triangles are marked.
       Existing marks are not modified.
   Returns:
-    If successfull, the new vertex at the center of the triangle fan.
+    If successful, the new vertex at the center of the triangle fan.
     Otherwise, nullptr is returned.
   */
   const class ON_SubDVertex* ReplaceFaceWithTriangleFan(
@@ -5195,7 +5195,7 @@ public:
     ci_list - [in]
     ci_count - [in]
     component_location - [in]
-      Select between applying the tranform to the control net (faster)
+      Select between applying the transform to the control net (faster)
       or the surface points (slower).
   Returns:
     Number of vertex locations that changed.
@@ -5429,7 +5429,7 @@ public:
 
   /*
   Description:
-    Search for a vertex with a specificed control net point.
+    Search for a vertex with a specified control net point.
   Parameters:
     control_net_point - [in]
       Look for a vertex with this value for ControlNetPoint().
@@ -5448,7 +5448,7 @@ public:
 
   /*
   Description:
-    Search for a vertex with a specificed control net point. If one does not
+    Search for a vertex with a specified control net point. If one does not
     exist, add a new one.
   Parameters:
     control_net_point - [in]
@@ -5927,7 +5927,7 @@ public:
     TriangleFan = 3,
 
     ///<summary>
-    /// If the hole boundary has an even mumber of edges, a quad fan is used.
+    /// If the hole boundary has an even number of edges, a quad fan is used.
     /// Otherwise a triangle fan is used. The center of the fan
     /// is the average of the hole boundary vertex control net points.
     ///</summary>
@@ -6112,7 +6112,7 @@ public:
 
   /*
   Description:
-    Expert user tool to remove a connection beteen an edge and vertex
+    Expert user tool to remove a connection between an edge and vertex
   Parameters:
     e - [in]
       An edge with zero attached faces.
@@ -6129,7 +6129,7 @@ public:
 
   /*
   Description:
-    Expert user tool to remove a connection beteen an edge and edge->vertex[evi]
+    Expert user tool to remove a connection between an edge and edge->vertex[evi]
   Parameters:
     e - [in]
       An edge with zero attached faces.
@@ -6146,7 +6146,7 @@ public:
 
   /*
   Description:
-    Expert user tool to remove all edge and vertex connnections from a face
+    Expert user tool to remove all edge and vertex connections from a face
   Parameters:
     face - [in]
   Remarks:
@@ -6187,7 +6187,7 @@ public:
   Description:
     This function copies cached evaluations of component subdivision points and limit
     surface information from src to this. Typically this is done for performance critical
-    sitations like control point editing.
+    situations like control point editing.
   */
   bool CopyEvaluationCacheForExperts(const ON_SubD& src);
 
@@ -6254,7 +6254,7 @@ public:
     ///<summary>
     /// NURBS surfaces will be as large as possible without the addition of extra knots. 
     /// Near extraordinary vertices, the surfaces may have lots of knots.
-    /// This option is prefered when a user wants larger NURBS surfaces but not at the cost of addtional NURBS control points.
+    /// This option is preferred when a user wants larger NURBS surfaces but not at the cost of additional NURBS control points.
     ///</summary>
     Medium = 2,
 
@@ -6289,7 +6289,7 @@ public:
     image_height = [in]
       If a texture image size is known, pass it here. Otherwise pass 0.0 for both parameters.
   Returns:
-    Suggested way to partition a texture coodinate domain into rectangles.
+    Suggested way to partition a texture coordinate domain into rectangles.
     ON_2udex.i = "x" count
     ON_2udex.j = "y" count
     For example (3,2) would mean divide the 2d texture domain into 3 segments across and 2 segments vertically.
@@ -6345,7 +6345,7 @@ public:
     this->SetTextureCoordinateMapping() to set the mapping.
 
     Calling this->SetTextureCoordinateType() does not change existing cached
-    texture coordinates. At an approprite time, call SetFragmentTextureCoordinates()
+    texture coordinates. At an appropriate time, call SetFragmentTextureCoordinates()
     to update texture coordinates on any cached fragments.
 
     SubD texture coordinate type and fragment texture coordinates are a mutable property.
@@ -6396,7 +6396,7 @@ public:
     is ON_SubDTextureCoordinateType::FromMapping.
 
     Calling this->SetTextureMappingTag() does not change existing cached
-    texture coordinates. At an approprite time, call this->SetFragmentTextureCoordinates()
+    texture coordinates. At an appropriate time, call this->SetFragmentTextureCoordinates()
     to update texture coordinates on any cached fragments.
 
     SubD texture domains and coordinates are a mutable property.
@@ -6408,7 +6408,7 @@ public:
   Returns:
     True if setting texture coordinates requires a set ON_TextureMapping mapping.
   Remarks:
-    An explict texture mapping is required when TextureCoordinateType() is
+    An explicit texture mapping is required when TextureCoordinateType() is
     ON_SubDTextureCoordinateType::FromMapping and TextureMappingTag()
     is set and not ON_MappingTag::SurfaceParameterMapping or an equivalent
     surface parameter mapping.
@@ -6513,7 +6513,7 @@ public:
       hash depend on this->RenderContentSerialNumber().
     fragment_colors_mapping_tag - [in]
       If not applicable, pass ON_MappingTag::Unset.
-      A mapping tag indentifying what is setting the fragment colors.
+      A mapping tag identifying what is setting the fragment colors.
       This is the only property that persists in SubD copies and saves in 3dm archives.
       Typically:
         m_mapping_id is an id you make up that identifies what is setting the colors (thickness, curvature, ...).
@@ -6546,7 +6546,7 @@ public:
     ) const;
 
   /*
-  Descrption:
+  Description:
     Clear all fragment vertex colors
   Parameters:
     bClearFragmentColorsMappingTag - [in]
@@ -6574,7 +6574,7 @@ public:
     Set the fragment colors mapping tag.
   Remarks:
     Calling this->SetFragmentColorsMappingTag() does not change existing cached
-    fragment vertex colors. At an approprite time, call this->SetFragmentColorsFromCallback()
+    fragment vertex colors. At an appropriate time, call this->SetFragmentColorsFromCallback()
     to update fragment vertex colors on any cached fragments.
 
     SubD fragment vertex tag and colors are a mutable property.
@@ -6653,7 +6653,7 @@ public:
         does not match this->SubDTopologyHash(), then this->FacePackingSubDTopologyHash() is updated
         to the current value of this->SubDTopologyHash().
 
-        If this paramter is false and and this->FacePackingSubDTopologyHash()
+        If this parameter is false and and this->FacePackingSubDTopologyHash()
         does not match this->SubDTopologyHash(), then the function returns false.
     Returns:
       True if FacesArePacked() is true, the quad grids meet all the conditions described above,
@@ -6760,7 +6760,7 @@ private:
 #pragma ON_PRAGMA_WARNING_POP
 
 public:
-  // The ON_SubD code increments ON_SubD::ErrorCount everytime something
+  // The ON_SubD code increments ON_SubD::ErrorCount every time something
   // unexpected happens. This is useful for debugging.
   static unsigned int ErrorCount;
 }; 
@@ -7204,7 +7204,7 @@ public:
   //
   //     Q = 3/8 * (A + B) = 3/4 * (1/2*A + 1/2*B)
   //
-  //   A crease edge's subdivision point is alwasy the edge's midpoint.
+  //   A crease edge's subdivision point is always the edge's midpoint.
   /*
   Description:
     Calculates sector weight value for the sector type
@@ -7650,16 +7650,16 @@ public:
     Get the subdivision matrix for the default subdivison algorithms 
     used by ON_SubD.
 
-    The matrix coefficents are ordered so that the matrix acts on
+    The matrix coefficients are ordered so that the matrix acts on
     the left of the points returned by ON_SubDSectorIterator::GetVertexRing().
 
-    For an interior vertex (smooth or dart), the coefficents are ordered
+    For an interior vertex (smooth or dart), the coefficients are ordered
     so that one iteration of subdivision is given by:
     S*Transpose(V, E[0], F[0], E[1], F[1], ..., E[N-1], F[N-1]).
     For a dart vertex, E[0] is the point at the end of the creased edge.
 
 
-    For a boundary vertex (crease or corner), the coefficents are ordered
+    For a boundary vertex (crease or corner), the coefficients are ordered
     so that one iteration of subdivision is given by:
     S*Transpose(V, E[0], F[0], E[1], F[1], ..., F[N-2], E[N-1]).
 
@@ -7672,7 +7672,7 @@ public:
   Parameters:
     S - [out]
       subdivision matrix
-      Matrix coefficent (i,j) = S[i][j]
+      Matrix coefficient (i,j) = S[i][j]
       0 <= i < R, 0 <= j < R, R = ON_SubDSectorType.PointRingCount()
     matrix_capacity - [in]
       S[] can store any RxR matrix with R <= matrix_capacity.
@@ -7691,7 +7691,7 @@ public:
   Parameters:
     S - [out]
       subdivision matrix. 
-      Matrix coefficent (i,j) = S[i*R + j],
+      Matrix coefficient (i,j) = S[i*R + j],
       0 <= i < R, 0 <= j < R, R = ON_SubDSectorType.PointRingCount()
     S_capacity - [in]
       Number of elements in S[] array
@@ -7731,12 +7731,12 @@ public:
       The sector type is not set.
 
     2: 
-      The subdominant eigenvalue has algebraic and geometric multiplicty = 2.
+      The subdominant eigenvalue has algebraic and geometric multiplicity = 2.
       This is the most common case.
 
     1: 
-      The subdominant eigenvalue has algebraic and geometric multiplicty = 1.
-      This occures in Catmull-Clark subdivision at a crease vertex with 
+      The subdominant eigenvalue has algebraic and geometric multiplicity = 1.
+      This occurs in Catmull-Clark subdivision at a crease vertex with 
       two crease edges and a single face.  The subdivision matrix for this
       case is
         S is a 4 x 4 matrix with rows =
@@ -7744,7 +7744,7 @@ public:
            (1/2, 1/2, 0, 0),
            (1/4, 1/4, 1/4, 1/4), 
            (1/2, 0, 0, 1/2).
-        S has 4 real eigenvalues = (1, 1/2, 1/4, 1/4), all wtih
+        S has 4 real eigenvalues = (1, 1/2, 1/4, 1/4), all with
         geometric multiplicity = 1.
         The three eigenvectors are
            (1, 1, 1, 1), (0, -1, 0, 1), (0, 0, 1, 0).
@@ -7786,7 +7786,7 @@ public:
     E2_capacity - [in]
       Capacity of the E2[] array.
     E2 - [out]
-      When E1_capacity > 0 and E2_capacity > 0, two orthoganal eigenvectors
+      When E1_capacity > 0 and E2_capacity > 0, two orthogonal eigenvectors
       spanning the subdivision matrix subdominant eigenspace are returned
       in E1[] and E2[].
       If one of E1_capacity or E2_capacity is > 0, then both must be > 0.
@@ -7854,7 +7854,7 @@ public:
       The eigenvalues are (1, lambda, lambda, e3, ..., eR), where
       1 > lambda > e3 >= ... >= eR > 0.
     0: 
-      Invalid input or the eigenvalues for this sector typoe are not available.
+      Invalid input or the eigenvalues for this sector type are not available.
   */
   unsigned int GetAllEigenvalues(
     double* eigenvalues,
@@ -8257,7 +8257,7 @@ public:
   
   // m_F_count = number of quads
   //           = m_side_segment_count*m_side_segment_count
-  // (0,1,4,16,256,1024,4096) Afer 0, each permitted value is 4x previous value
+  // (0,1,4,16,256,1024,4096) After 0, each permitted value is 4x previous value
   unsigned short m_F_count;
 
   // m_F_level_of_detail is poorly named. It should be named m_F_mesh_density_reduction.
@@ -8303,7 +8303,7 @@ public:
       point capacity to store the specified density.
 
     this - [out]
-      This must have a point capacity large enough to accomodate the
+      This must have a point capacity large enough to accommodate the
       requested display density.
 
   */
@@ -8347,7 +8347,7 @@ public:
   Remarks:
     The number of points is the same for quad or tri subdivision limit
     mesh fragments, even though one is a rectanglular collection of 
-    quads and the other is a trianglular collection of triangles.
+    quads and the other is a triangular collection of triangles.
   */
   static unsigned int PointCountFromDisplayDensity(
     unsigned int display_density
@@ -8375,7 +8375,7 @@ public:
 
   /*
   Returns:
-    If side_segment_count is valide, then (side_segment_count+1) is returned.
+    If side_segment_count is valid, then (side_segment_count+1) is returned.
     Otherwise 0 is returned.
   */
   static unsigned int SidePointCountFromSideCount(
@@ -8384,7 +8384,7 @@ public:
 
   /*
   Returns:
-    If side_segment_count is valide, then (side_segment_count+1)^2 is returned.
+    If side_segment_count is valid, then (side_segment_count+1)^2 is returned.
     Otherwise 0 is returned.
   */
   static unsigned int QuadGridPointCountFromSideCount(
@@ -8393,7 +8393,7 @@ public:
 
   /*
   Returns:
-    If side_segment_count is valide, then side_segment_count^2 is returned.
+    If side_segment_count is valid, then side_segment_count^2 is returned.
     Otherwise 0 is returned.
   */
   static unsigned int QuadGridQuadCountFromSideCount(
@@ -8455,7 +8455,7 @@ public:
     dst - [in/out]
       The 3d point (src[0],src[1],src2[2]) is copied to (dst[0],dst[1],dst[2]).
   Returns:
-    True if a copy occured.
+    True if a copy occurred.
   */
   static bool SealPoints(
     bool bTestNearEqual,
@@ -8473,7 +8473,7 @@ public:
     dst - [in/out]
       The 3d point (src[0],src[1],src2[2]) is copied to (dst[0],dst[1],dst[2]).
   Returns:
-    True if a copy occured.
+    True if a copy occurred.
   */
   static bool SealNormals(
     bool bTestNearEqual,
@@ -8830,7 +8830,7 @@ public:
     grid_corner_index - [in]
       0, 1, 2, or 3
   Returns:
-    vertex color at the grid corner or ON_Color::UnsetColor if thre are not vertex colors.
+    vertex color at the grid corner or ON_Color::UnsetColor if there are not vertex colors.
   Remarks:
     For partial fragments (IsFaceCornerFragment() = true), grid_corner_index = 2 is the only
     corner that corresponds to a SubD vertex.
@@ -8953,7 +8953,7 @@ public:
   unsigned short m_face_fragment_index; // First fragment has index = 0. Last fragment has index = m_face_fragment_count-1.
 
   // The mesh fragment is a grid of quads.
-  // There are m_side_count quad edges along each side of the tesselation,
+  // There are m_side_count quad edges along each side of the tessellation,
   // There are a total of m_side_count X m_side_count quads, and
   // m_P_count = (m_side_count+1)*(m_side_count+1).
 
@@ -9181,7 +9181,7 @@ private:
   // in ON_SubDMeshFragment gid order.
   // The m_pack_rect[] points are in grid order. If the parent ON_SubDFace pack rect is rotated,
   // then "lower/upper" and "left/right" are with the rotation applied and hence a lower/left coordinate
-  // may be greater than an upper/right coorinate value.
+  // may be greater than an upper/right coordinate value.
   //  m_pack_rect[0] "lower left"
   //  m_pack_rect[1] "lower right"
   //  m_pack_rect[2] "upper left"
@@ -9219,7 +9219,7 @@ public:
     When an ON_SubDFace is a quad, it is rendered with one ON_SubDMeshFragment.
     When an ON_SubDFace is a 3-gon, it is rendered with three ON_SubDMeshFragments.
   Remarks:
-    It is critcial that m_face_fragment_count and m_face_fragment_index be set
+    It is critical that m_face_fragment_count and m_face_fragment_index be set
     correctly before calling this function.
     A ON_SubDMeshFragment used to render a quad ON_SubDFace has
     m_face_fragment_count = 1 and m_face_fragment_index = 0.
@@ -9249,10 +9249,10 @@ public:
       These three parameters are values from ON_SubDFace::GetNgonSubPackRectSizeAndDelta().
       ngon_grid_size, ngon_sub_pack_rect_size, and ngon_sub_pack_rect_delta are identical
       for all the ON_SubDMeshFragments used to render the n-gon face. The value of
-      m_face_fragment_index detemines which sub pack rect is assigned to each of
+      m_face_fragment_index determines which sub pack rect is assigned to each of
       the n ON_SubDMeshFragments use to render the n-gon face.
   Remarks:
-    It is critcial that m_face_fragment_count and m_face_fragment_index be set
+    It is critical that m_face_fragment_count and m_face_fragment_index be set
     correctly before calling this function.
     A ON_SubDMeshFragment used to render an n-gon ON_SubDFace has
     m_face_fragment_count = n and m_face_fragment_index = 0, ..., n-1.
@@ -9309,7 +9309,7 @@ public:
       These three parameters are values from ON_SubDFace::GetNgonSubPackRectSizeAndDelta().
       ngon_grid_size, ngon_sub_pack_rect_size, and ngon_sub_pack_rect_delta are identical
       for all the ON_SubDMeshFragments used to render the n-gon face. The value of
-      m_face_fragment_index detemines which sub pack rect is assigned to each of
+      m_face_fragment_index determines which sub pack rect is assigned to each of
       the n ON_SubDMeshFragments use to render the n-gon face.
     fragment_pack_rect_corners - [out]
   */
@@ -9417,8 +9417,8 @@ public:
   // The m_N[] and m_P[] arrays are parallel. 
   // Depending on the strides, m_P[], m_N[], and m_T[] can be separate or interlaced.
   //
-  // If m_N is not nullptr and m_N_stride>0, then m_N[] can accomodate up to m_P_capacity normals.
-  // If m_N is not nullptr and m_N_stride=0, then m_N[] can accomodate a single normal (flat shaded polygon face).
+  // If m_N is not nullptr and m_N_stride>0, then m_N[] can accommodate up to m_P_capacity normals.
+  // If m_N is not nullptr and m_N_stride=0, then m_N[] can accommodate a single normal (flat shaded polygon face).
   // The stride m_N_stride and memory m_N references is managed by some other class or function.
   // Never modify m_N_stride, m_N, or the values in m_N.
   // Use m_grid functions to get normal indices and quad face indices.
@@ -9444,7 +9444,7 @@ public:
   //
   // Depending on the strides, m_P[], m_N[], and m_T[] can be separate or interlaced.
   //
-  // If m_T is not nullptr and m_T_stride>0, then m_T[] can accomodate up to m_P_capacity textures coordinates.
+  // If m_T is not nullptr and m_T_stride>0, then m_T[] can accommodate up to m_P_capacity textures coordinates.
   // Otherwise there are no texture coordinates.
   // Never modify m_T_stride, m_T.
   // Use m_grid functions to get texture indices and quad face indices.
@@ -9486,7 +9486,7 @@ public:
     A quad ON_SubDFace is rendered with one ON_SubDMeshFragment.
     A 3-gon ON_SubDFace is rendered with three ON_SubDMeshFragments.
   Remarks:
-    It is critcial that m_face_fragment_count and m_face_fragment_index be set
+    It is critical that m_face_fragment_count and m_face_fragment_index be set
     correctly before calling this function.
     A ON_SubDMeshFragment used to render a quad ON_SubDFace has
     m_face_fragment_count = 1 and m_face_fragment_index = 0.
@@ -9516,10 +9516,10 @@ public:
       These three parameters are values from ON_SubDFace::GetNgonSubPackRectSizeAndDelta().
       ngon_grid_size, ngon_sub_pack_rect_size, and ngon_sub_pack_rect_delta are identical
       for all the ON_SubDMeshFragments used to render the n-gon face. The value of
-      m_face_fragment_index detemines which sub pack rect is assigned to each of
+      m_face_fragment_index determines which sub pack rect is assigned to each of
       the n ON_SubDMeshFragments use to render the n-gon face.
   Remarks:
-    It is critcial that m_face_fragment_count and m_face_fragment_index be set
+    It is critical that m_face_fragment_count and m_face_fragment_index be set
     correctly before calling this function.
     A ON_SubDMeshFragment used to render an n-gon ON_SubDFace has
     m_face_fragment_count = n and m_face_fragment_index = 0, ..., n-1.
@@ -9583,7 +9583,7 @@ private:
   //
   // Depending on the strides, m_P[], m_N[], m_T[] and m_C[] can be separate or interlaced.
   //
-  // If m_C is not nullptr and m_C_stride>0, then m_C[] can accomodate up to m_P_capacity 
+  // If m_C is not nullptr and m_C_stride>0, then m_C[] can accommodate up to m_P_capacity 
   // elements.
   // Otherwise there is no per vertex false color.
   // Never modify m_C_stride, m_C.
@@ -9661,7 +9661,7 @@ private:
   //
   // Principal curvatures
   //
-  // If m_K is not nullptr and m_K_stride>0, then m_K[] can accomodate up to m_P_capacity 
+  // If m_K is not nullptr and m_K_stride>0, then m_K[] can accommodate up to m_P_capacity 
   // principal curvatures and sectional curvatures (four doubles, k1,k2,sx,sy).
   // Otherwise there are no principal curvatures or sectional curvatures.
   // (sx = sectional curvature in grid "x" direction, sy = sectional curvature in grid "y" direction.)
@@ -9719,7 +9719,7 @@ public:
 
 public:
 
-  // Normalized grid parameters useful for appling a texture to the grid are available
+  // Normalized grid parameters useful for applying a texture to the grid are available
   // from m_grid functions.
   
   // Information to resolve m_P[], m_N[], and m_T[] into a grid of NxN quads.
@@ -9823,7 +9823,7 @@ public:
       allocated with a call to new ON_Mesh().
   Returns:
     If this limit mesh is not empty, an ON_Mesh representation of this limit mesh.
-    Othewise, nullptr.
+    Otherwise, nullptr.
   */
   ON_Mesh* ToMesh(
     ON_Mesh* destination_mesh
@@ -9841,7 +9841,7 @@ public:
       allocated with a call to new ON_Mesh().
   Returns:
     If this limit mesh is not empty, an ON_Mesh representation of this limit mesh.
-    Othewise, nullptr.
+    Otherwise, nullptr.
   */
   ON_Mesh* ToMesh(
     unsigned int mesh_density,
@@ -9862,7 +9862,7 @@ public:
       allocated with a call to new ON_Mesh().
   Returns:
     If this limit mesh is not empty, an ON_Mesh representation of this limit mesh.
-    Othewise, nullptr.
+    Otherwise, nullptr.
   */
   static ON_Mesh* ToMesh(
     class ON_SubDMeshFragmentIterator& frit,
@@ -10112,7 +10112,7 @@ public:
   /*
   Returns:
     True if this component is active in its parent subd or other
-    relevent context.
+    relevant context.
   Remarks:
     When a component is in use, IsActive() = true. 
     If was used and then deleted, IsActive() is false.
@@ -10198,7 +10198,7 @@ public:
     Any code can use Mark() at any time. You cannot assume that
     other functions including const will not change its value.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   */
   bool Mark() const;
 
@@ -10211,7 +10211,7 @@ public:
     Any code can use Mark() at any time. You cannot assume that
     other functions including const will not change its value.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -10226,7 +10226,7 @@ public:
     Any code can use Mark() at any time. You cannot assume that
     other functions including const will not change its value.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -10243,7 +10243,7 @@ public:
     Any code can use Mark() at any time. You cannot assume that
     other functions including const will not change its value.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
   Returns:
     Input value of Mark().
   */
@@ -10262,7 +10262,7 @@ public:
     Any code can use MarkBits() at any time. You cannot assume that
     other functions including const will not change their value.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state. 
+    components that are in a certain context specific state. 
 
     MarkBits() is used in more complex calculations where the single true/false
     provided by Mark() is not sufficient. Typically MarkBits() is used when
@@ -10282,7 +10282,7 @@ public:
     Any code can use MarkBits() at any time. You cannot assume that
     other functions including const will not change their value.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
 
     MarkBits() is used in more complex calculations where the single true/false
     provided by Mark() is not sufficient. Typically MarkBits() is used when
@@ -10306,7 +10306,7 @@ public:
     Any code can use MarkBits() at any time. You cannot assume that
     other functions including const will not change their value.
     It is widely used in many calculations to keep track of sets of
-    components that are in a certain context specfic state.
+    components that are in a certain context specific state.
 
     MarkBits() is used in more complex calculations where the single true/false
     provided by Mark() is not sufficient. Typically MarkBits() is used when
@@ -10344,7 +10344,7 @@ public:
   /*
   Description:
     Clears saved subdivision and limit surface information for this component.
-    Attached components are not modifed.
+    Attached components are not modified.
   */
   void ClearSavedSubdivisionPoint() const;
 
@@ -10382,7 +10382,7 @@ public:
 
   /*
   Returns:
-    True if the subdivision displacment vector is valid and not zero.
+    True if the subdivision displacement vector is valid and not zero.
   */
   bool SubdivisionDisplacementIsNonzero() const;
 
@@ -10524,7 +10524,7 @@ public:
   Returns:
     True if this component is marked as a primary motif component.
   Remarks:
-    You must use ON_SubD SymmetrySet memeber functions to get symmetry set contents.
+    You must use ON_SubD SymmetrySet member functions to get symmetry set contents.
   */
   bool IsSymmetrySetPrimaryMotif() const;
 
@@ -10532,7 +10532,7 @@ public:
   Returns:
     True if this component is marked being in a symmetry set.
   Remarks:
-    You must use ON_SubD SymmetrySet memeber functions to get symmetry set contents.
+    You must use ON_SubD SymmetrySet member functions to get symmetry set contents.
   */
   bool InSymmetrySet() const;
 
@@ -10684,7 +10684,7 @@ public:
   /*
   Description:
     Clears saved subdivision and limit surface information for this vertex.
-    Attached edges and faces are not modifed.
+    Attached edges and faces are not modified.
   */
   void ClearSavedSubdivisionPoints() const;  
 
@@ -10891,7 +10891,7 @@ public:
   ///*
   //Description:
   //  Sort the m_edges[] and m_faces[] arrays so radial groups are together.
-  //  After the sorting is completed, m_vertex_edge_order is set to recored
+  //  After the sorting is completed, m_vertex_edge_order is set to recorded
   //  the current sorting state and its value is returned.  
   //  The sorting is done unconditionally.
   //*/
@@ -10938,7 +10938,7 @@ public:
     new_face = [in]
       If new_face is nullptr, old_face is simply removed.
   Returns:
-    If the replacement was successful, then the m_faces[] array index where old_face/new_face replacement occured is returned.
+    If the replacement was successful, then the m_faces[] array index where old_face/new_face replacement occurred is returned.
     Otherwise ON_UNSET_UINT_INDEX is returned.
   Remarks:
     No modifications are made to old_face or new_face.
@@ -11027,7 +11027,7 @@ public:
     vei1 - [out]
       If a vertex has exactly two attached edges, each of which has a single attached face,
       then the indices of those edges in the vertex's edge list are returned. 
-      Othewise ON_UNSET_UINT_INDEX is returned.
+      Otherwise ON_UNSET_UINT_INDEX is returned.
   Returns:
     True if the vertex has exactly two attached edges, each of which has a single attached face.
     False otherwise.
@@ -11041,12 +11041,12 @@ public:
   Description:
     A "standard" vertex is one where the standard subdivsion matrix for that vertex
     can be used to calculate the subdivision point. 
-    This function is desinged to be useful for testing and debugging code when
+    This function is designed to be useful for testing and debugging code when
     a certain situation is expected to exist.  It is not used for evaluation
     because it is too slow.
 
   Returns:
-    True if the subdivison point of the vertex can be calulated using the standard
+    True if the subdivison point of the vertex can be calculated using the standard
     subdivion matrix for the vertex type and face count.
 
   Remarks:
@@ -11459,7 +11459,7 @@ public:
   /*
   Description:
     Clears saved subdivision and limit surface information for this edge.
-    Attached vertices and faces are not modifed.
+    Attached vertices and faces are not modified.
   */
   void ClearSavedSubdivisionPoints() const;  
 
@@ -11822,7 +11822,7 @@ public:
     new_face = [in]
       If new_face is nullptr, old_face is simply removed.
   Returns:
-    If the replacement was successful, then the m_faces[] array index where old_face/new_face replacement occured is returned.
+    If the replacement was successful, then the m_faces[] array index where old_face/new_face replacement occurred is returned.
     Otherwise ON_UNSET_UINT_INDEX is returned.
   Remarks:
     No modifications are made to old_face or new_face.
@@ -12144,7 +12144,7 @@ public:
   /*
   Description:
     Clears saved subdivision and limit surface information for this face.
-    Attached edges and vertices are not modifed.
+    Attached edges and vertices are not modified.
   */
   void ClearSavedSubdivisionPoints() const;
 
@@ -12261,7 +12261,7 @@ private:
   // Packing information is saved in 3dm files.
   unsigned int m_pack_id = 0;
 
-  // Location of this face's pack rectin normaized coordinates
+  // Location of this face's pack rectin normalized coordinates
   // Each face is assigned a unique rectangle in the unit square (0,1)x(0,1). 
   // Groups of quad faces packed together.
   // If faces are added to an existing subd, the pack rects for the entire subd must be recalculated.
@@ -12472,7 +12472,7 @@ public:
       vector from lower left corner to upper right corner.
       Valid deltas have (0 < delta.x, 0 < delta.y, (origin.x+delta.x) <= 1) and (origin.y+delta.y) <= 1.
     packing_rotation_degrees - [in]
-      Valid packing_rotation_degrees are a mulitple of 90.
+      Valid packing_rotation_degrees are a multiple of 90.
   Returns:
     True if the input parameters define a valid pack rectangle.
   */
@@ -12511,7 +12511,7 @@ public:
       vector from lower left corner to upper right corner.
       Valid deltas have (0 < delta.x, 0 < delta.y, (origin.x+delta.x) <= 1) and (origin.y+delta.y) <= 1.
     packing_rotation_degrees - [in]
-      Valid packing_rotation_degrees are a mulitple of 90.
+      Valid packing_rotation_degrees are a multiple of 90.
   Return:
     True if input is valid and the pack rectangle was set.
     False if the input was not vaie and the pack rectangle coordinates were set to nan.
@@ -12525,7 +12525,7 @@ public:
   /*
   Description:
     Calculate how a packing rectangle assigned to an ON_SubDFace will
-    be subdivided into n sub packing rectanges for an ngon when n >= 5.
+    be subdivided into n sub packing rectangles for an ngon when n >= 5.
   Parameters:
     ngon_edge_count - [in]
       >= 5.
@@ -12572,7 +12572,7 @@ private:
   // The application specifies a base ON_Material used to render the subd this face belongs to.
   // If m_material_channel_index > 0 AND face_material_id = base.MaterialChannelIdFromIndex(m_material_channel_index)
   // is not nil, then face_material_id identifies an override rendering material for this face.
-  // Othewise base will be used to render this face.
+  // Otherwise base will be used to render this face.
   mutable unsigned short m_material_channel_index = 0;
 
 public:
@@ -12616,7 +12616,7 @@ private:
   // The application specifies a base ON_Material used to render the subd this face belongs to.
   // If m_material_channel_index > 0 AND face_material_id = base.MaterialChannelIdFromIndex(m_material_channel_index)
   // is not nil, then face_material_id identifies an override rendering material for this face.
-  // Othewise base will be used to render this face.
+  // Otherwise base will be used to render this face.
   mutable ON_Color m_per_face_color = ON_Color::UnsetColor;
 
 public:
@@ -12773,7 +12773,7 @@ public:
 private:
   // If m_texture_points is not nullptr, it has capacity 4 + m_edgex_capacity.
   // Custom texture coordinates are stored in m_texture_points.
-  // When texture coodinates are packed or come from a mapping,
+  // When texture coordinates are packed or come from a mapping,
   // m_texture_points is not used. Typically m_texture_points
   // is used when an ON_SubD is created from an ON_Mesh and the mesh
   // has custom texture coordinates. Here "custom" means
@@ -13325,37 +13325,37 @@ public:
     const class ON_SubDRef& subd_ref
     );
 
-  // Construct and interator that iterates over a single vertex.
+  // Construnt an iterator that iterates over a single vertex.
   ON_SubDVertexIterator(
     const class ON_SubD& subd,
     const class ON_SubDVertex& vertex
     );
 
-  // Construct and interator that iterates over a single vertex.
+  // Construnt an iterator that iterates over a single vertex.
   ON_SubDVertexIterator(
     const class ON_SubDRef& subd_ref,
     const class ON_SubDVertex& vertex
     );
 
-  // Construct and interator that iterates over the vertices of an edge.
+  // Construnt an iterator that iterates over the vertices of an edge.
   ON_SubDVertexIterator(
     const class ON_SubD& subd,
     const class ON_SubDEdge& edge
     );
 
-  // Construct and interator that iterates over the vertices of an edge.
+  // Construnt an iterator that iterates over the vertices of an edge.
   ON_SubDVertexIterator(
     const class ON_SubDRef& subd_ref,
     const class ON_SubDEdge& edge
     );
 
-  // Construct and interator that iterates over the vertices of a face.
+  // Construnt an iterator that iterates over the vertices of a face.
   ON_SubDVertexIterator(
     const class ON_SubD& subd,
     const class ON_SubDFace& face
     );
 
-  // Construct and interator that iterates over the vertices of a face.
+  // Construnt an iterator that iterates over the vertices of a face.
   ON_SubDVertexIterator(
     const class ON_SubDRef& subd_ref,
     const class ON_SubDFace& face
@@ -13412,7 +13412,7 @@ public:
 
   /*
   Return:
-    Interator index of the current vertex.
+    Iterator index of the current vertex.
   */
   unsigned int CurrentVertexIndex() const
   {
@@ -13588,37 +13588,37 @@ public:
     const class ON_SubDRef& subd_ref
     );
 
-  // Construct and interator that iterates over a single edge.
+  // Construnt an iterator that iterates over a single edge.
   ON_SubDEdgeIterator(
     const class ON_SubD& subd,
     const class ON_SubDEdge& edge
     );
 
-  // Construct and interator that iterates over a single edge.
+  // Construnt an iterator that iterates over a single edge.
   ON_SubDEdgeIterator(
     const class ON_SubDRef& subd_ref,
     const class ON_SubDEdge& edge
     );
 
-  // Construct and interator that iterates over the edges of a vertex.
+  // Construnt an iterator that iterates over the edges of a vertex.
   ON_SubDEdgeIterator(
     const class ON_SubD& subd,
     const class ON_SubDVertex& vertex
     );
 
-  // Construct and interator that iterates over the edges of a vertex.
+  // Construnt an iterator that iterates over the edges of a vertex.
   ON_SubDEdgeIterator(
     const class ON_SubDRef& subd_ref,
     const class ON_SubDVertex& vertex
     );
 
-  // Construct and interator that iterates over the edges of a face.
+  // Construnt an iterator that iterates over the edges of a face.
   ON_SubDEdgeIterator(
     const class ON_SubD& subd,
     const class ON_SubDFace& face
     );
 
-  // Construct and interator that iterates over the edges of a face.
+  // Construnt an iterator that iterates over the edges of a face.
   ON_SubDEdgeIterator(
     const class ON_SubDRef& subd_ref,
     const class ON_SubDFace& face
@@ -13675,7 +13675,7 @@ public:
 
   /*
   Return:
-    Interator index of the current edge.
+    Iterator index of the current edge.
   */
   unsigned int CurrentEdgeIndex() const
   {
@@ -13851,37 +13851,37 @@ public:
     const class ON_SubDRef& subd_ref
     );
 
-  // Construct and interator that iterates over the single face.
+  // Construnt an iterator that iterates over the single face.
   ON_SubDFaceIterator(
     const class ON_SubD& subd,
     const class ON_SubDFace& face
     );
 
-  // Construct and interator that iterates over the single face.
+  // Construnt an iterator that iterates over the single face.
   ON_SubDFaceIterator(
     const class ON_SubDRef& subd_ref,
     const class ON_SubDFace& face
     );
 
-  // Construct and interator that iterates over the faces of a vertex.
+  // Construnt an iterator that iterates over the faces of a vertex.
   ON_SubDFaceIterator(
     const class ON_SubD& subd,
     const class ON_SubDVertex& vertex
     );
 
-  // Construct and interator that iterates over the faces of a vertex.
+  // Construnt an iterator that iterates over the faces of a vertex.
   ON_SubDFaceIterator(
     const class ON_SubDRef& subd_ref,
     const class ON_SubDVertex& vertex
     );
 
-  // Construct and interator that iterates over the faces of an edge.
+  // Construnt an iterator that iterates over the faces of an edge.
   ON_SubDFaceIterator(
     const class ON_SubD& subd,
     const class ON_SubDEdge& edge
     );
 
-  // Construct and interator that iterates over the faces of an edge.
+  // Construnt an iterator that iterates over the faces of an edge.
   ON_SubDFaceIterator(
     const class ON_SubDRef& subd_ref,
     const class ON_SubDEdge& edge
@@ -13938,7 +13938,7 @@ public:
 
   /*
   Return:
-    Interator index of the current face.
+    Iterator index of the current face.
   */
   unsigned int CurrentFaceIndex() const
   {
@@ -13960,7 +13960,7 @@ public:
 
   /*
   Description:
-    Returns the next face and incrments the iterator.
+    Returns the next face and increments the iterator.
   Returns:
     Next face.
   Remarks:
@@ -14174,7 +14174,7 @@ public:
 
   /*
   Description:
-    Returns the next component and incrments the iterator.
+    Returns the next component and increments the iterator.
   Returns:
     Next component.
   Remarks:
@@ -14924,7 +14924,7 @@ public:
     ///<summary>The option is not set.</summary>
     Unset = 0,
 
-    ///<summary>No convex coners.</summary>
+    ///<summary>No convex corners.</summary>
     None = 1,
 
     ///<summary>A convex subd corner will appear at input mesh boundary vertices 
@@ -15028,7 +15028,7 @@ public:
     ///<summary>The option is not set.</summary>
     Unset = 0,
 
-    ///<summary>No concave coners. In general, this is the best choice.</summary>
+    ///<summary>No concave corners. In general, this is the best choice.</summary>
     None = 1,
 
     ///<summary>A concave subd corner will appear at input mesh boundary vertices 
@@ -15151,14 +15151,14 @@ public:
   //
 #pragma region RH_C_SHARED_ENUM [ON_SubDFromMeshParameters::TextureCoordinatesOption] [Rhino.Geometry.SubDCreationOptions.TextureCoordinateOption] [nested:byte]
   /// <summary>
-  /// Specifies how texture coordinate information is transfered from the mesh to the SubD.
+  /// Specifies how texture coordinate information is transferred from the mesh to the SubD.
   /// </summary>
   enum class TextureCoordinatesOption : unsigned char
   {
     ///<summary>The option is not set.</summary>
     Unset = 0,
 
-    ///<summary>No texture coordianate information is transfered from the mesh.</summary>
+    ///<summary>No texture coordianate information is transferred from the mesh.</summary>
     None = 1,
 
     ///<summary>
@@ -15169,7 +15169,7 @@ public:
     Automatic = 2,
 
     ///<summary>
-    /// No texture coordianate information is transfered from the mesh.
+    /// No texture coordianate information is transferred from the mesh.
     /// The SubD faces are packed.
     ///</summary>
     Packed = 3,
@@ -15182,7 +15182,7 @@ public:
 
     ///<summary>
     /// If a mesh has custom texture coordinates, the custom texture coordinates 
-    /// are transfered to the SubD. This requires more memory resources, 
+    /// are transferred to the SubD. This requires more memory resources, 
     /// slows subdivision evaluation, often produces unattractive
     /// results on n-gons, and distorts the texture when comes from a common mapping
     /// technique, like planar. This option may be useful when the mesh contains only 
@@ -15448,7 +15448,7 @@ public:
 
   /*
   Description:
-    Expert user function to transfer managment of an ON_SubDComponentRef on the heap
+    Expert user function to transfer management of an ON_SubDComponentRef on the heap
     to this class.
   */
   const ON_SubDComponentRef& AppendForExperts(ON_SubDComponentRef*& ref);
@@ -15456,7 +15456,7 @@ public:
   /*
   Description:
     Expert user function to append a ON_SubDComponentRef to the identified component.
-    The expert user is responsible for insuring subd exists fot the lifetime of this
+    The expert user is responsible for insuring subd exists for the lifetime of this
     class.
   */
   const ON_SubDComponentRef& AppendForExperts(
@@ -15500,7 +15500,7 @@ public:
 
   /*
   Returns:
-    If the list is clean, the number of subd objects in the list. Mutiple components can belong to the same SubD.
+    If the list is clean, the number of subd objects in the list. Multiple components can belong to the same SubD.
     If the list is not clean, 0.
   Remarks:
     Use Clean() to get a clean list.
@@ -15629,7 +15629,7 @@ public:
     B - [in]
   Returns:
     A pick point for the component the user was most likely aiming at
-    with distance and depth settings that will lead to conistent improvment
+    with distance and depth settings that will lead to conistent improvement
     if more than two points are being compared.
   */
   static const ON_SubDComponentPoint BestPickPoint(
@@ -15756,7 +15756,7 @@ public:
   // algorithm.
   //
   // If If "C" is a boundary vertex (m_vertex_tag is crease or corner), the conditions
-  // listed above are satisified except 
+  // listed above are satisfied except 
   // E[0] and E[N-1] are tagged as crease edges, 
   // P[0] and P[N-1] are tagged as crease vertices (NOT corners), 
   // and there are N-2 faces,
@@ -15796,9 +15796,9 @@ public:
   // V1 = m_L1[0]*vertexR[0] + ... + m_L1[R-1]*vertexR[R-1].
   // V2 = m_L2[0]*vertexR[0] + ... + m_L2[R-1]*vertexR[R-1].
   // span the tangent plane and 
-  // N = V1 x V2 is perpindicular to the limit tangent plane.
+  // N = V1 x V2 is perpendicular to the limit tangent plane.
   // In general and almost always in practice, V1 and V2 are not unit vectors
-  // and it is best to noramalize V1 and V2 before taking the cross product.
+  // and it is best to normalize V1 and V2 before taking the cross product.
   // m_L1 and m_L2 are subdominant eigenvectors of Transpose(m_S).
   // When the subdominant eigenvalue has geometric multiplicity 2, 
   // m_L1 and m_L2 span the same space as m_E1 and m_E2. 
@@ -16337,7 +16337,7 @@ public:
       ON_ChainDirection::Previous or ON_ChainDirection::Next.
       The search direction is relative to this->EdgeDirection().
     chain_type - [in]
-      Determines what edge/vertex tag conditions must be satisified by the neighbor.
+      Determines what edge/vertex tag conditions must be satisfied by the neighbor.
   Returns:
     The next or previous edge in the chain if it exists.
     Otherwise, nullptr is returned.
@@ -16361,7 +16361,7 @@ public:
       ON_ChainDirection::Previous or ON_ChainDirection::Next.
       The search direction is relative to this->EdgeDirection().
     chain_type - [in]
-      Determines what edge/vertex tag conditions must be satisified by the neighbor.
+      Determines what edge/vertex tag conditions must be satisfied by the neighbor.
     bEnableStatusCheck - [in]
     status_pass - [in]
     status_fail - [in]
@@ -16969,7 +16969,7 @@ public:
 
   /*
   Description:
-    CLears the refernce to the SubD and removes all RTree nodes.
+    CLears the reference to the SubD and removes all RTree nodes.
   */
   void Clear();
 
@@ -16994,7 +16994,7 @@ public:
   /*
   Parameters:
     bMarkFilter - [in]
-      Vertices with Mark = bMarkFilter are eligable to be found.
+      Vertices with Mark = bMarkFilter are eligible to be found.
       Vertices with Mark != bMarkFilter are ignored.
   */
   static const ON_SubDRTreeVertexFinder Create(const ON_3dPoint P, bool bMarkFilter);
@@ -17004,7 +17004,7 @@ public:
   double m_distance = ON_DBL_QNAN;
   const ON_SubDVertex* m_v = nullptr;
 
-  // When m_bMarkFilterEnabled is true, then vertices with Mark() == m_bMarkFilter are eligable
+  // When m_bMarkFilterEnabled is true, then vertices with Mark() == m_bMarkFilter are eligible
   // to be found and vertices with Mark() != m_bMarkFilter are ignored.
   bool m_bMarkFilterEnabled = false;
   bool m_bMarkFilter = false;

--- a/opennurbs_subd_archive.cpp
+++ b/opennurbs_subd_archive.cpp
@@ -1054,7 +1054,7 @@ bool ON_SubDFace::Write(
         break;
     }
 
-    // Custom texture coordintes
+    // Custom texture coordinates
     const bool bTexturePoints = this->TexturePointsAreSet();
     if (false == Internal_WriteComponentAdditionSize(bTexturePoints, archive, 4))
       break;
@@ -1225,7 +1225,7 @@ bool ON_SubDFace::Read(
     }
 
 
-    // Custom texture coordintes
+    // Custom texture coordinates
     sz = 0;
     if (false == Internal_ReadComponentAdditionSize(archive, 4, &sz))
       break;
@@ -1247,7 +1247,7 @@ bool ON_SubDFace::Read(
       ON_3dPoint a[10];
       bool bContinue = true;
 
-      // Even if allocaion fails, we need to read the points so we can get get
+      // Even if allocation fails, we need to read the points so we can get get
       // future information that is after the points out of the archive.
       subdimple->AllocateFaceTexturePoints(f);
       ON_3dPoint* tp = f->m_texture_points;
@@ -1358,7 +1358,7 @@ unsigned int ON_SubDLevel::SetArchiveId(
         if (prev_id >= c->m_id)
         {
           // This is a serious error!
-          // Contine because this allows us to save something do the disk in these bad cases.
+          // Continue because this allows us to save something do the disk in these bad cases.
           ON_SUBD_ERROR("The m_id values of the active components in the fixed size pool are corrupt.");
         }
         else
@@ -1373,7 +1373,7 @@ unsigned int ON_SubDLevel::SetArchiveId(
       if (cidit_level_count != linked_list_count)
       {
         // This is a serious error!
-        // Contine because this allows us to save something do the disk in these bad cases.
+        // Continue because this allows us to save something do the disk in these bad cases.
         ON_SUBD_ERROR("The m_level values of the active components in the fixed size pool are corrupt.");
       }
       break;
@@ -1913,7 +1913,7 @@ bool ON_SubDimple::Read(
   //
   // No changes to "this SubD" below here.
   // 
-  // The rest is updating infomation that is used to determine if this SubD
+  // The rest is updating information that is used to determine if this SubD
   // is the same SubD that existed when symmetry and texture information
   // was saved. It's ok if this is not the same subd. If and when appropriate
   // something downstream will update either the SubD or the symmetry/texture 

--- a/opennurbs_subd_data.h
+++ b/opennurbs_subd_data.h
@@ -291,7 +291,7 @@ public:
 
   /*
   Description:
-    Get the limit sub surface exact patch for the specifed corner.
+    Get the limit sub surface exact patch for the specified corner.
   Returns:
     true when srf_cv are set to a the CVs for a bicubic uniform cubic NURBS bispan patch
   */
@@ -420,7 +420,7 @@ void ON_SubDIncrementErrorCount(); // defined in opennurbs_subd.cpp
 // that store a pointer to an ON_SubDVertex, ON_SubDEdge, or ON_SubDFace
 // along with a direction bit that is 0 or 1. The direction bit is used
 // to indicate if the component is being referenced with its 
-// natrual orientation (0) or the reverse of its natural orientaion (1).
+// natural orientation (0) or the reverse of its natural orientation (1).
 //
 // ON_SubDComponentPtr is an unsigned int that stores a pointer to an 
 // ON_SubDVertex, ON_SubDEdge, or ON_SubDFace, the direction bit
@@ -646,7 +646,7 @@ public:
 public:
   /*
   Returns:
-    Number of changes to vertex tag, edge tag and edge sector coefficent values.
+    Number of changes to vertex tag, edge tag and edge sector coefficient values.
   */
   unsigned int UpdateEdgeTags(
     bool bUnsetEdgeTagsOnly
@@ -1651,7 +1651,7 @@ public:
       + m_fsp_oddball_fragments.SizeOfUnusedElements()
       + m_fsp_limit_curves.SizeOfUnusedElements();
 
-    // It has alwasy been the case that count0 = count1 = ON_SubDDisplayParameters::MaximumDensity + 1.
+    // It has always been the case that count0 = count1 = ON_SubDDisplayParameters::MaximumDensity + 1.
     // But a wrong answer is better than crashing if somebody incorrectly modifies ON_SubDHeap 
     // in the far future.
     const size_t count0 = sizeof(m_unused_fragments) / sizeof(m_unused_fragments[0]);
@@ -1734,12 +1734,12 @@ private:
   // m_full_fragment_display_density = display density for a full fragment
   unsigned int m_full_fragment_display_density = 0;
 
-  // m_full_fragment_count_estimate = an esitmate of the total number of full fragments
-  // needed. It's ok if we need additionaly fragments later.
+  // m_full_fragment_count_estimate = an estimate of the total number of full fragments
+  // needed. It's ok if we need additionally fragments later.
   unsigned int m_full_fragment_count_estimate = 0;
 
-  // m_full_fragment_count_estimate = an esitmate of the total number of full fragments
-  // needed. It's ok if we need additionaly fragments later.
+  // m_full_fragment_count_estimate = an estimate of the total number of full fragments
+  // needed. It's ok if we need additionally fragments later.
   unsigned int m_part_fragment_count_estimate = 0;
 
   unsigned int m_reserved0 = 0;
@@ -1879,7 +1879,7 @@ public:
   /*
   Returns:
     A runtime serial number that is incremented every time a the active level,
-    vertex location, vertex or edge flag, or subd topology is chaned.
+    vertex location, vertex or edge flag, or subd topology is changed.
   */
   ON__UINT64 GeometryContentSerialNumber() const;
 
@@ -1905,7 +1905,7 @@ public:
 
   /*
   Description:
-    Change the geoemtry content serial number to indicate something affecting
+    Change the geometry content serial number to indicate something affecting
     the geometric shape of the subd has changed. This includes topologial changes,
     vertex and edge tag changes, and changes to vertex control net locations.
   Parameters:
@@ -2066,7 +2066,7 @@ public:
   /*
   Description:
     Split and edge.
-    The input edge is modifed to terminate at the input vertex.
+    The input edge is modified to terminate at the input vertex.
     The new edge begins at the input vertex and ends at the final vertex
     of the original input edge.
   edge - [in]
@@ -2974,7 +2974,7 @@ private:
 class /*DO NOT EXPORT*/ ON_SubDEdgeSurfaceCurve
 {
 public:
-  // Use CopyFrom() when proper managment of m_cvx is required.
+  // Use CopyFrom() when proper management of m_cvx is required.
   // This class is used internally and never seen int developer SDK.
   static const ON_SubDEdgeSurfaceCurve Unset; // all doubles are ON_UNSET_VALUE, everything else is zero.
   static const ON_SubDEdgeSurfaceCurve Nan;   // all doubles are ON_DBL_QNAN, everything else is zero
@@ -3003,7 +3003,7 @@ public:
       (-2,-1,0,1,2,3,...,cv_count-1).
   Remarks:
     The knot vector is unclamped to permit efficient joining of adjacent edge
-    curves into longer NURBS with simple interior knots. This occures frequently.
+    curves into longer NURBS with simple interior knots. This occurs frequently.
   */
   bool SetCVs(
     int cv_count,
@@ -3026,7 +3026,7 @@ public:
     with unclamped knot vector (-2,-1,0,1,2,3,...,cv_count-1).
   Remarks:
     The knot vector is unclamped to permit efficient joining of adjacent edge
-    curves into longer NURBS with simple interior knots. This occures frequently.
+    curves into longer NURBS with simple interior knots. This occurs frequently.
   */
   unsigned int GetCVs(
     size_t cv_capacity,

--- a/opennurbs_subd_eval.cpp
+++ b/opennurbs_subd_eval.cpp
@@ -1115,7 +1115,7 @@ const ON_SubDMeshFragment * ON_SubDFace::MeshFragments() const
 {
   // NOTE:
   // Clearing the ON_SubDComponentBase::SavedPointsFlags::SurfacePointBit bit
-  // on m_saved_points_flags is used to mark mesh fragmants as dirty. 
+  // on m_saved_points_flags is used to mark mesh fragments as dirty. 
   // They need to be regerated before being used.
   return (0 != ON_SUBD_CACHE_LIMITLOC_FLAG(m_saved_points_flags)) ? m_mesh_fragments : nullptr;
 }

--- a/opennurbs_subd_fragment.cpp
+++ b/opennurbs_subd_fragment.cpp
@@ -1863,7 +1863,7 @@ unsigned int ON_SubDMeshFragmentGrid::SidePointCount() const
 
 unsigned int ON_SubDMeshFragmentGrid::GridFaceCount() const
 {
-  // TODO: Suport tri fragments
+  // TODO: Support tri fragments
   unsigned int side_segment_count = SideSegmentCount();
   return side_segment_count * side_segment_count;
 }
@@ -1871,7 +1871,7 @@ unsigned int ON_SubDMeshFragmentGrid::GridFaceCount() const
 
 unsigned int ON_SubDMeshFragmentGrid::GridPointCount() const
 {
-  // TODO: Suport tri fragments
+  // TODO: Support tri fragments
   unsigned int side_segment_count = SideSegmentCount();
   return (side_segment_count > 0U) ? ((side_segment_count + 1U)*(side_segment_count + 1U)) : 0U;
 }
@@ -2116,7 +2116,7 @@ ON_SubDMeshFragmentGrid ON_SubDMeshFragmentGrid::QuadGridFromDisplayDensity(
     }
 
     // Do not initialize grid_cache[i] until entire linked list is ready to be used.
-    // This way if the lock is stolen for some unforseen reason, we risk leaking memory
+    // This way if the lock is stolen for some unforeseen reason, we risk leaking memory
     // but we will not crash.
     grid_cache[i] = first_lod;
   }
@@ -2658,7 +2658,7 @@ public:
         else
         {
           // this is an inteior edge of a partial fragment and it
-          // is alwasy sealed with its neighbor when it is created.
+          // is always sealed with its neighbor when it is created.
           break;
         }
       }

--- a/opennurbs_subd_frommesh.cpp
+++ b/opennurbs_subd_frommesh.cpp
@@ -387,7 +387,7 @@ class ON_NgonBoundaryChecker
 {
 public:
   /*
-  Parametes:
+  Parameters:
     ngon  - [in]
       ngon to test
     mesh [in]
@@ -631,7 +631,7 @@ ON_SubD* ON_SubD::Internal_CreateFromMeshWithValidNgons(
       if (ngon_orientation < 0)
       {
         // ngon and mesh have opposite orientations - mesh orientation wins
-        // reverese edges
+        // reverse edges
         unsigned int i0 = mesh_edge_count;
         unsigned int i1 = mesh_edge_count + ngon_edge_count - 1;
         while (i0 < i1)
@@ -790,7 +790,7 @@ ON_SubD* ON_SubD::Internal_CreateFromMeshWithValidNgons(
   //
 
   // mesh_edge_map[] is used to sort the sort mesh_edges[] into groups that correspond to the same SubD edge.
-  // The order of mesh_edges[] cannot be changed because the current order is neede to efficiently create the SubD faces.
+  // The order of mesh_edges[] cannot be changed because the current order is needed to efficiently create the SubD faces.
   unsigned int* mesh_edge_map = (unsigned int*)ws.GetMemory(mesh_edges.UnsignedCount() * sizeof(mesh_edge_map[0]));
   ON_Sort(
     ON::sort_algorithm::quick_sort,
@@ -1259,7 +1259,7 @@ ON_SubD* ON_SubD::CreateSubDBox(
     }
   }
 
-  // Make interior vertexes and store 3d indexes
+  // Make interior vertices and store 3d indexes
   for (unsigned int ix = 0; ix <= facecount_x; ix++)
   {
     for (unsigned int iy = 0; iy <= facecount_y; iy++)
@@ -1977,7 +1977,7 @@ bool ON_NgonBoundaryChecker::IsSimpleNgon(
   for (ON_NgonBoundaryComponent* e = (ON_NgonBoundaryComponent * )fspit.FirstElement(); nullptr != e; e = (ON_NgonBoundaryComponent * )fspit.NextElement())
   {
     if (1 != e->m_face_count)
-      continue; // vertex components alwasy have m_face_count = 0;
+      continue; // vertex components always have m_face_count = 0;
 
     // e is a boundary edge
     if (bBoundaryIsMarked)

--- a/opennurbs_subd_heap.cpp
+++ b/opennurbs_subd_heap.cpp
@@ -951,7 +951,7 @@ class ON_SubDComponentBase* ON_SubDHeap::Internal_AllocateComponentAndSetId(
   {
     // Requests for a candidate_id value above 3 billion are ignored to insure
     // there is plenty of room for ids. 
-    // It's almost certainly a bug if candidate_id > several millon or so.
+    // It's almost certainly a bug if candidate_id > several million or so.
     candidate_id = 0; 
   }
 

--- a/opennurbs_subd_iter.cpp
+++ b/opennurbs_subd_iter.cpp
@@ -1773,7 +1773,7 @@ const ON_SubDFace* ON_SubDSectorIterator::IncrementFace(
       if (edge != ON_SUBD_EDGE_POINTER(face1_edges->m_ptr))
         continue;
 
-      // At this point, face1->Edges(fei) is the edge I just hopped accross
+      // At this point, face1->Edges(fei) is the edge I just hopped across
       // to get from the old current face to face 1. Update current face
       // information and return.
       m_current_face = face1; 

--- a/opennurbs_subd_limit.cpp
+++ b/opennurbs_subd_limit.cpp
@@ -2474,7 +2474,7 @@ bool ON_SubDQuadNeighborhood::Subdivide(
     fedges[2] = fsh.AllocateEdge(
       bUseFindOrAllocate,
       vertex_grid1[0][3],
-      at_crease_weight, // ingored unless vertex_grid1[0][3] is tagged as a crease
+      at_crease_weight, // ignored unless vertex_grid1[0][3] is tagged as a crease
       vertex_grid1[0][2],
       ON_SubDSectorType::IgnoredSectorCoefficient
       );
@@ -2819,10 +2819,10 @@ bool ON_SubDFaceNeighborhood::QuadSubdivideHelper(
     if (vertex0->m_edge_count < 2)
       return ON_SUBD_RETURN_ERROR(false);
    
-    // One of the main reasons for creating a ON_SubDFaceNeighborhood is to calcualte the 
+    // One of the main reasons for creating a ON_SubDFaceNeighborhood is to calculate the 
     // limit mesh and limit cubic surfaces when the original face is not a quad.  
     // For these calculations, we need to calculate and save the limit point for extraordinary
-    // verticies while enough information is available to calculate it.  Doing the calculation
+    // vertices while enough information is available to calculate it.  Doing the calculation
     // before calling m_fsh.AllocateVertex(), insures the information will be copied to vertex1.
     if ( false == vertex0->GetSurfacePoint(face,limit_point) )
       return ON_SUBD_RETURN_ERROR(false);
@@ -2851,7 +2851,7 @@ bool ON_SubDFaceNeighborhood::QuadSubdivideHelper(
       center_vertex1,
       ON_SubDSectorType::IgnoredSectorCoefficient,
       vertex1,
-      at_crease2_weight // ingored unless vertex1 is tagged as a crease
+      at_crease2_weight // ignored unless vertex1 is tagged as a crease
       );
     if ( edge1.IsNull() )
       return ON_SUBD_RETURN_ERROR(false);
@@ -3012,7 +3012,7 @@ bool ON_SubDFaceNeighborhood::QuadSubdivideHelper(
       return ON_SUBD_RETURN_ERROR(false);
     edge1 = m_fsh.AllocateEdge(
       ring_vertex1[2],
-      at_crease2_weight, // ingored unless ring_vertex1[0] is tagged as a crease
+      at_crease2_weight, // ignored unless ring_vertex1[0] is tagged as a crease
       vertex1,
       ON_SubDSectorType::IgnoredSectorCoefficient
       );

--- a/opennurbs_subd_matrix.cpp
+++ b/opennurbs_subd_matrix.cpp
@@ -735,7 +735,7 @@ bool ON_SubDMatrix::EvaluateCosAndSin(
   if ( e > 1e-12 )
   {
     ON_SubDIncrementErrorCount();
-    ON_ERROR("Bug in SinCosEv precision improvment code.");
+    ON_ERROR("Bug in SinCosEv precision improvement code.");
   }
 #endif
 
@@ -3329,7 +3329,7 @@ double ON_SubDMatrix::TestEvaluation(
 //#define ON_SUBD_JORDON_DECOMP_CODE
 #if defined (ON_SUBD_JORDON_DECOMP_CODE)
 
-// This code is not required for ON_SubD evaulation.
+// This code is not required for ON_SubD evaluation.
 // It was of theoretical interest early in the project.
 
 class ON_NumberPolisher

--- a/opennurbs_subd_ring.cpp
+++ b/opennurbs_subd_ring.cpp
@@ -565,7 +565,7 @@ const ON_SubDVertex* ON_SubD::SubdivideSector(
   if ( nullptr == vertex1)
     return ON_SUBD_RETURN_ERROR(nullptr);
 
-  // at_crease weight is used when the cooresponding vertex is a crease.
+  // at_crease weight is used when the corresponding vertex is a crease.
   // Otherwise, fsh.AllocateEdge() ignores at_crease_weight.
   ON_SubDEdgeTag edge1_tag = (ON_SubDEdgeTag::SmoothX == edge0_tag) ? ON_SubDEdgeTag::Smooth : edge0_tag;
   const double at_crease_weight 

--- a/opennurbs_sumsurface.h
+++ b/opennurbs_sumsurface.h
@@ -265,7 +265,7 @@ public:
               possible to repeatedly call GetNextDiscontinuity
               and step through the discontinuities.
     t1 - [in] (t0 != t1)  If there is a discontinuity at t1 is 
-              will be ingored unless c is a locus discontinuity
+              will be ignored unless c is a locus discontinuity
               type and t1 is at the start or end of the curve.
     t - [out] if a discontinuity is found, then *t reports the
           parameter at the discontinuity.
@@ -276,7 +276,7 @@ public:
         discontinuity found at *t.  A value of 1 means the first 
         derivative or unit tangent was discontinuous.  A value 
         of 2 means the second derivative or curvature was 
-        discontinuous.  A value of 0 means teh curve is not
+        discontinuous.  A value of 0 means the curve is not
         closed, a locus discontinuity test was applied, and
         t1 is at the start of end of the curve.
     cos_angle_tolerance - [in] default = cos(1 degree) Used only

--- a/opennurbs_surface.cpp
+++ b/opennurbs_surface.cpp
@@ -445,7 +445,7 @@ bool ON_Surface::GetNextDiscontinuity(
     {
       // 20 March 2003 Dale Lear:
       //   Have to look for locus discontinuities at ends.
-      //   Must test both ends becuase t0 > t1 is valid input.
+      //   Must test both ends because t0 > t1 is valid input.
       //   In particular, for ON_CurveProxy::GetNextDiscontinuity() 
       //   to work correctly on reversed "real" curves, the 
       //   t0 > t1 must work right.

--- a/opennurbs_surface.h
+++ b/opennurbs_surface.h
@@ -436,7 +436,7 @@ public:
               possible to repeatedly call GetNextDiscontinuity
               and step through the discontinuities.
     t1 - [in] (t0 != t1)  If there is a discontinuity at t1 is 
-              will be ingored unless c is a locus discontinuity
+              will be ignored unless c is a locus discontinuity
               type and t1 is at the start or end of the curve.
     t - [out] if a discontinuity is found, then *t reports the
           parameter at the discontinuity.
@@ -447,7 +447,7 @@ public:
         discontinuity found at *t.  A value of 1 means the first 
         derivative or unit tangent was discontinuous.  A value 
         of 2 means the second derivative or curvature was 
-        discontinuous.  A value of 0 means teh curve is not
+        discontinuous.  A value of 0 means the curve is not
         closed, a locus discontinuity test was applied, and
         t1 is at the start of end of the curve.
     cos_angle_tolerance - [in] default = cos(1 degree) Used only
@@ -887,7 +887,7 @@ public:
   */
   void Set( const ON_Surface* surface );
 
-  bool m_bIsSet;           // True if Set() has been callled with a non-null surface.
+  bool m_bIsSet;           // True if Set() has been called with a non-null surface.
 
   bool m_bHasSingularity;  // true if at least one m_bSingular[] setting is true.
   bool m_bIsSingular[4];   // m_bSingular[i] = ON_Surface::IsSingular(i)

--- a/opennurbs_surfaceproxy.cpp
+++ b/opennurbs_surfaceproxy.cpp
@@ -254,7 +254,7 @@ ON_SurfaceProxy::IsIsoparametric( // returns isoparametric status of 2d curve
         const ON_Interval* subdomain
         ) const
 {
-  // this is a virtual overide of an ON_Surface::IsIsoparametric
+  // this is a virtual override of an ON_Surface::IsIsoparametric
 
   const ON_Curve* pC = &crv;
 	ON_Curve* pTranC = nullptr;
@@ -304,7 +304,7 @@ ON_SurfaceProxy::IsIsoparametric( // returns isoparametric status based on bound
         const ON_BoundingBox& box
         ) const
 {	
-  // this is a virtual overide of an ON_Surface::IsIsoparametric
+  // this is a virtual override of an ON_Surface::IsIsoparametric
 	const ON_BoundingBox* pbox = &box;
 	ON_BoundingBox Tbox(	ON_3dPoint( box.m_min[1],box.m_min[0],0.0),
 												ON_3dPoint( box.m_max[1],box.m_max[0],0.0) );

--- a/opennurbs_surfaceproxy.h
+++ b/opennurbs_surfaceproxy.h
@@ -196,7 +196,7 @@ public:
               possible to repeatedly call GetNextDiscontinuity
               and step through the discontinuities.
     t1 - [in] (t0 != t1)  If there is a discontinuity at t1 is 
-              will be ingored unless c is a locus discontinuity
+              will be ignored unless c is a locus discontinuity
               type and t1 is at the start or end of the curve.
     t - [out] if a discontinuity is found, then *t reports the
           parameter at the discontinuity.
@@ -207,7 +207,7 @@ public:
         discontinuity found at *t.  A value of 1 means the first 
         derivative or unit tangent was discontinuous.  A value 
         of 2 means the second derivative or curvature was 
-        discontinuous.  A value of 0 means teh curve is not
+        discontinuous.  A value of 0 means the curve is not
         closed, a locus discontinuity test was applied, and
         t1 is at the start of end of the curve.
     cos_angle_tolerance - [in] default = cos(1 degree) Used only

--- a/opennurbs_symmetry.cpp
+++ b/opennurbs_symmetry.cpp
@@ -455,7 +455,7 @@ bool ON_Symmetry::IsMotifBoundarySubDVertex(const class ON_SubDVertex* v, bool b
     d = fabs(this->ReflectionPlane().ValueAt(P));
     break;
   case ON_Symmetry::Type::Rotate:
-    // All boundary vertices must be eligable for joining.
+    // All boundary vertices must be eligible for joining.
     // The pinwheel motifs in RH-63376 show why.
     d = P.IsValid() ? 0.0 : ON_DBL_QNAN;
     break;
@@ -1960,7 +1960,7 @@ double ON_Symmetry::CleanupTolerance() const
 {
   // The default constructor sets m_cleanup_tolerance = 0.0.
   // Handling m_cleanup_tolerance this way insures that ON_Symmetry::CleanupTolerance()
-  // will always return ON_Symmetry::ZeroTolerance (which may chnage), even with class definitions 
+  // will always return ON_Symmetry::ZeroTolerance (which may change), even with class definitions 
   // read from old archives.
   return (m_cleanup_tolerance >= ON_Symmetry::ZeroTolerance) ? m_cleanup_tolerance : ON_Symmetry::ZeroTolerance;
 }

--- a/opennurbs_symmetry.h
+++ b/opennurbs_symmetry.h
@@ -100,7 +100,7 @@ public:
     Object = 1,
 
     /// <summary>
-    /// The symmetry is indepenent of any objects is it applied to.
+    /// The symmetry is independent of any objects is it applied to.
     /// The symmetry's planes and rotation axes are not changed when
     /// any of those objects are transformed.
     /// </summary>
@@ -164,7 +164,7 @@ public:
   static bool SymmetryRegionIsRotationPlane(ON_Symmetry::Region r);
 
   /*
-  Paramaters:
+  Parameters:
     r - [in]
     bInAndOutResult - [in]
      Value to return when ON_Symmetry::Region::InandOut == r.
@@ -174,7 +174,7 @@ public:
   static bool IsOn(ON_Symmetry::Region r, bool bInAndOutResult);
 
   /*
-  Paramaters:
+  Parameters:
     r - [in]
     bInAndOutResult - [in]
      Value to return when ON_Symmetry::Region::InandOut == r.
@@ -184,7 +184,7 @@ public:
   static bool IsInOrOn(ON_Symmetry::Region r, bool bInAndOutResult);
 
   /*
-  Paramaters:
+  Parameters:
     r - [in]
     bInAndOutResult - [in]
      Value to return when ON_Symmetry::Region::InandOut == r.
@@ -198,11 +198,11 @@ public:
     point - [in]
       point to test.
     bUseCleanupTolerance - [in]
-      The tolerance used to dermine if a point is On an axis or plane is
+      The tolerance used to determine if a point is On an axis or plane is
       bUseCleanupTolerance ? this->CleanupTolerance() : ON_Symmetry::ZeroTolerance.
       When in doubt, pass false.
   Returns:
-    The location of the point releative to the primary motif regions.
+    The location of the point relative to the primary motif regions.
   */
   ON_Symmetry::Region PointRegion(ON_3dPoint point, bool bUseCleanupTolerance) const;
 
@@ -218,7 +218,7 @@ public:
     v - [in]
       vertex to test
     bUseCleanupTolerance - [in]
-      The tolerance used to dermine if a point is On an axis or plane is
+      The tolerance used to determine if a point is On an axis or plane is
       bUseCleanupTolerance ? this->CleanupTolerance() : ON_Symmetry::ZeroTolerance.
       When in doubt, pass false.
   Returns:
@@ -239,7 +239,7 @@ public:
     transformation - [in]
     transformation_order - [in]
   Returns:
-    True if these 2 conditions are satisified.
+    True if these 2 conditions are satisfied.
     1. identity = transformation^transformation_order.
     2. identity != transformation^i for 1 <= i < transformation_order.
   Remarks:
@@ -276,7 +276,7 @@ public:
     reflection - [in]
     reflection_plane - [in]
   Returns:
-    True if these 3 conditions are satisified.
+    True if these 3 conditions are satisfied.
     1. identity = reflection^2
     2. identity != reflection
     3. Points on the reflection_plane are fixed.
@@ -292,7 +292,7 @@ public:
     rotation_count - [in]
     fixed_plane - [in]
   Returns:
-    True if these 3 conditions are satisified.
+    True if these 3 conditions are satisfied.
     1. rotation_axis is a valid line.
     2. rotation_count > 0
     3. fixed_plane contains the rotation axis.
@@ -503,19 +503,19 @@ public:
   const ON_UUID SymmetryId() const;
 
   /*
-  Descripton:
+  Description:
     Set this instance to ON_Symmetry::Unset.
   */
   void Clear();
 
   /*
-  Rturns:
+  Returns:
     True if this instance is set to a symmetry.
   */
   bool IsSet() const;
 
   /*
-  Rturns:
+  Returns:
     True if this instance is not set.
   */
   bool IsUnset() const;
@@ -634,35 +634,35 @@ public:
   /*
   Returns:
     If the symmetry is type is Reflect or ReflectAndRotate, then the reflection plane is returned.
-    Othewise ON_Plane::Nan is returned.
+    Otherwise ON_Plane::Nan is returned.
   */
   const ON_PlaneEquation ReflectionPlane() const;
 
   /*
   Returns:
     If the symmetry is type is Reflect or ReflectAndRotate, then the reflection plane is returned.
-    Othewise ON_Plane::Nan is returned.
+    Otherwise ON_Plane::Nan is returned.
   */
   const ON_Xform ReflectionTransformation() const;
 
   /*
   Returns:
     If the symmetry is type is Rotate or ReflectAndRotate, then the rotation axis is returned.
-    Othewise ON_Line::Nan is returned.
+    Otherwise ON_Line::Nan is returned.
   */
   const ON_Line RotationAxis() const;
 
   /*
   Returns:
     If the symmetry is type is Rotate or ReflectAndRotate, then a point on the rotation axis is returned.
-    Othewise ON_3dPoint::Nan is returned.
+    Otherwise ON_3dPoint::Nan is returned.
   */
   const ON_3dPoint RotationAxisPoint() const;
 
   /*
   Returns:
     If the symmetry is type is Rotate or ReflectAndRotate, then the direction of the rotation axis is returned.
-    Othewise ON_3dVector::Nan is returned.
+    Otherwise ON_3dVector::Nan is returned.
   Remarks:
     This vector may have length != 1
   */
@@ -671,21 +671,21 @@ public:
   /*
   Returns:
     If the symmetry is type is Rotate or ReflectAndRotate, then a unit vector in the direction of the rotation axis is returned.
-    Othewise ON_3dVector::Nan is returned.
+    Otherwise ON_3dVector::Nan is returned.
   */
   const ON_3dVector RotationAxisTangent() const;
 
   /*
   Returns:
     If the symmetry is type is Rotate or ReflectAndRotate, then the rotation count is returned.
-    Othewise 0 is returned.
+    Otherwise 0 is returned.
   */
   unsigned int RotationCount() const;
 
   /*
   Returns:
     If the symmetry is type is Rotate or ReflectAndRotate, then the rotation angle in degrees is returned.
-    Othewise ON_DBL_QNAN is returned.
+    Otherwise ON_DBL_QNAN is returned.
   Remarks:
     RotationAngleDegrees() = 360.0/RotationCount()
   */
@@ -701,7 +701,7 @@ public:
   /*
   Returns:
     If the symmetry is type is Rotate or ReflectAndRotate, then the rotation angle in radians is returned.
-    Othewise ON_DBL_QNAN is returned.
+    Otherwise ON_DBL_QNAN is returned.
   Remarks:
     RotationAngleRadians() = (2.0*ON_PI)/RotationCount()
   */
@@ -710,7 +710,7 @@ public:
   /*
   Returns:
     If the symmetry is type is Rotate or ReflectAndRotate, then the plane defining the zero angle or rotation is returned.
-    Othewise ON_PlaneEquation::NanPlaneEquation is returned.
+    Otherwise ON_PlaneEquation::NanPlaneEquation is returned.
   Remarks:
     For a Rotate symmetry, the region on or above RotationZeroPlane() and above RotationOnePlane()
     is the default primary motif region.
@@ -722,7 +722,7 @@ public:
   /*
   Returns:
     If the symmetry is type is Rotate or ReflectAndRotate, then (RotationTransformation() * RotationOnePlane()).NegatedPlaneEquation() is returned.
-    Othewise ON_PlaneEquation::NanPlaneEquation is returned.
+    Otherwise ON_PlaneEquation::NanPlaneEquation is returned.
   Remarks:
     For a Rotate symmetry, the region on or above RotationZeroPlane() and above RotationOnePlane()
     is the default primary motif region.
@@ -742,14 +742,14 @@ public:
 
   /*
   Description:
-    If SymmetryCoordinates() = ON_Symmetry::Coordinates::Object, then the symmetry defition
+    If SymmetryCoordinates() = ON_Symmetry::Coordinates::Object, then the symmetry definition
     is transformed.
   */
   const ON_Symmetry TransformConditionally(const ON_Xform& xform) const;
 
   /*
   Description:
-    The the symmetry defition is transformed.
+    The the symmetry definition is transformed.
   */
   const ON_Symmetry TransformUnconditionally(const ON_Xform& xform) const;
 
@@ -759,7 +759,7 @@ public:
     A SHA1 hash value that uniquely identifies the symmetry settings.
   Remarks:
     The symmetric object content serial number and symmetric object hashes 
-    are not incuded in the symmetry hash.
+    are not included in the symmetry hash.
   */
   const ON_SHA1_Hash SymmetryHash() const;
 
@@ -910,7 +910,7 @@ private:
   // m_rotation_axis always lies in m_plane.
   ON_Line m_rotation_axis = ON_Line::NanLine;
 
-  // Using 0.0 insures the default returned by CleanupTolerance() is alwasy ON_Symmetry::ZeroTolerance.
+  // Using 0.0 insures the default returned by CleanupTolerance() is always ON_Symmetry::ZeroTolerance.
   double m_cleanup_tolerance = 0.0;
 
 private:

--- a/opennurbs_system.h
+++ b/opennurbs_system.h
@@ -339,7 +339,7 @@ typedef ON__UINT32 wchar_t;
 //
 // BEGIN - OBSOLETE  defines
 //
-// These legacy defines will be remvoed from V6
+// These legacy defines will be removed from V6
 //
 */
 
@@ -415,7 +415,7 @@ typedef ON__UINT32 wchar_t;
 
 #if defined(ON_RUNTIME_WIN) && !defined(NOGDI)
 /*
-// ok to use Windows GDI RECT, LOGFONT, ... stucts.
+// ok to use Windows GDI RECT, LOGFONT, ... structs.
 */
 #define ON_OS_WINDOWS_GDI
 #endif
@@ -653,11 +653,11 @@ typedef ON__UINT32 wchar_t;
 //   Its support for multiple locale names is limited.
 //   Its support for PANOSE1 is limited.
 //   It does not support font substitution.
-// Windows uses the Direct Write SDK for font and glyph calcuations.
-// MacOS and iOS use the Apple Core Text SDK for font and glyph calcuations.
+// Windows uses the Direct Write SDK for font and glyph calculations.
+// MacOS and iOS use the Apple Core Text SDK for font and glyph calculations.
 
 #if defined(ON_RUNTIME_ANDROID)
-// May work reasonably for Andoid versions < 8-ish as of Sep 2018.
+// May work reasonably for Android versions < 8-ish as of Sep 2018.
 // Test carefully if working right is important.
 
 // We are currently not using Freetype in OpenNURBS at all.

--- a/opennurbs_system_compiler.h
+++ b/opennurbs_system_compiler.h
@@ -163,10 +163,10 @@
 
 #if !defined(OPENNURBS_WALL) && !defined(ON_COMPILING_OPENNURBS)
 /* 
-// TEMPORARY C4456 SUPRESSION Feb 17 2016 - WILL BE REMOVED ASAP
+// TEMPORARY C4456 SUPPRESSION Feb 17 2016 - WILL BE REMOVED ASAP
 // Rhino code is still too dirty to leave 4456 on.
 */
-// Supress Warning C4456 declaration of '...' hides previous local declaration ...	
+// Suppress Warning C4456 declaration of '...' hides previous local declaration ...	
 #pragma ON_PRAGMA_WARNING_DISABLE_MSC(4456)
 #endif
 
@@ -188,7 +188,7 @@
 /////////////////////////////////////////////////////////////////////////////////////
 //
 // Dale Lear April 2017.
-// The Visual Stuido 2017 default is to disable warnings 4263, 4264, 4265, 4266
+// The Visual Studio 2017 default is to disable warnings 4263, 4264, 4265, 4266
 //
 // These are the warnings that help detect abuse of virtual functions and failed attempts
 // to override virtual functions.

--- a/opennurbs_system_runtime.h
+++ b/opennurbs_system_runtime.h
@@ -179,7 +179,7 @@
 #endif
 
 #if !defined(ON_64BIT_RUNTIME) && !defined(ON_32BIT_RUNTIME)
-/* Attempt to determing runtime pointer size */
+/* Attempt to determine runtime pointer size */
 #if (defined(_M_X64) || defined(__LP64__) || defined(__ppc64__))
 #define ON_64BIT_RUNTIME
 #elif (defined(_M_X86) || defined(__LP32__))

--- a/opennurbs_text.cpp
+++ b/opennurbs_text.cpp
@@ -2052,7 +2052,7 @@ bool ON_TextContent::MeasureTextRunArray(
           line_height = run->TextHeight();   // Increase height if this is highest run so far in this line
         double lfh = ON_TextContent::GetLinefeedHeight(*run);
         if (line_start || lfh > linefeed_height)
-          linefeed_height = lfh;         // Increase linefeed height if this is the higest so far in this line
+          linefeed_height = lfh;         // Increase linefeed height if this is the highest so far in this line
         line_start = false;
         line_end = false;
         last_text_run = run;

--- a/opennurbs_text.h
+++ b/opennurbs_text.h
@@ -121,7 +121,7 @@ public:
   /*
   Returns:
     True if this text position information used to create this text
-    is identical to the text position paramters on dimstyle.
+    is identical to the text position parameters on dimstyle.
   */
   bool EqualTextPositionProperties(
     ON::AnnotationType annotation_type,
@@ -198,7 +198,7 @@ public:
   /*
   Returns:
     Rich text suitable for initializing SDK controls on the current platform (Windows or Apple OS X).
-    The returned string is alwasy rich text (never plain text).
+    The returned string is always rich text (never plain text).
     The returned rich text is always generated directly from the runs.
     This text is typically different from the Rhino clean rich text returned by the RichText() command.
   */
@@ -210,7 +210,7 @@ public:
     rich_text_style - [in]
       Type of rich text to return.
   Returns:
-    The returned string is alwasy rich text (never plain text).
+    The returned string is always rich text (never plain text).
     The returned rich text is always generated directly from the runs.
     This text is typically different from the Rhino clean rich text returned by the RichText() command.
   */
@@ -368,7 +368,7 @@ public:
   //Parameters:
   //  dimsytle - [in]
   //Returns:
-  //  true if style was passed as dimstyle paramter to Create(), ReplaceTextString(),
+  //  true if style was passed as dimstyle parameter to Create(), ReplaceTextString(),
   //  or RebuildRuns() and used to create the current text runs.
   //*/
   //bool IsCurrentDimStyle(

--- a/opennurbs_textglyph.cpp
+++ b/opennurbs_textglyph.cpp
@@ -311,7 +311,7 @@ int ON_FontGlyph::GetGlyphList
     textlength,
     code_points.Array(),
     textlength,
-    nullptr,    // error status - ingnored
+    nullptr,    // error status - ignored
     0xFFFFFFFF, // mask as many errors as possible
     ON_UnicodeCodePoint::ON_ReplacementCharacter,  // unicode error mark when string is incorrectly encoded
     nullptr     // pointer to end of parsed text is ignored
@@ -959,7 +959,7 @@ const ON_FontGlyph* ON_GlyphMap::FindGlyph(const ON__UINT32 unicode_codepoint) c
 
 const ON_FontGlyph* ON_GlyphMap::InsertGlyph(const ON_FontGlyph& glyph )
 {
-  // managed glyphs are app resources - 1 per glpyh as needed and never freed.
+  // managed glyphs are app resources - 1 per glyph as needed and never freed.
   ON_MemoryAllocationTracking disable_tracking(false);
 
   if ( glyph.IsManaged() )

--- a/opennurbs_textiterator.cpp
+++ b/opennurbs_textiterator.cpp
@@ -486,7 +486,7 @@ void ON_TextBuilder::CharSet(const wchar_t* value)  // \fcharsetN
     if(ReadingFontDefinition())
     {
       // This is a charset specification in a font definition in the font table
-      // the value is convertable to a codepage to use for interpreting the text chars
+      // the value is convertible to a codepage to use for interpreting the text chars
       // using this font into unicode points
       m_current_props.SetCharSet(charset, true);
     }
@@ -2843,7 +2843,7 @@ bool ON_RtfParser::Parse()
             break;
 
           case '\'':
-            // This case sould never occur - it is handled by 
+            // This case should never occur - it is handled by 
             // Internal_ParseMBCSString at the beginning of this while statement.
             ON_ERROR("Bug in RTF parsing code.");
             break;
@@ -3053,7 +3053,7 @@ static bool GetRunText(ON_TextRun* run, ON_wString& text_out, bool& foundunicode
         // The RTF we get from Windows controls, like the "Text" command dialog box,
         // typically specifies it is using Windows-1252 and encodes the Euro sign as \`80.
         // So, if we have one of these "euro like" values, we will explicitly write it as a UNICODE value
-        // to avoid the possiblity of something defaulting to using Windows-1252.
+        // to avoid the possibility of something defaulting to using Windows-1252.
         // https://mcneel.myjetbrains.com/youtrack/issue/RH-38205
         //
         // See ON_DecodeWindowsCodePage1252Value() for more details.

--- a/opennurbs_textlog.cpp
+++ b/opennurbs_textlog.cpp
@@ -1261,7 +1261,7 @@ void ON_TextHash::AppendText(const char* s)
       m_remap_id_list.AddPair(original_id, sequential_id);
     }
 
-    // accumlate string version of sequential_id
+    // accumulate string version of sequential_id
     char sequential_id_str[40];
     ON_UuidToString(sequential_id, sequential_id_str);
     sequential_id_str[36] = 0;

--- a/opennurbs_textlog.h
+++ b/opennurbs_textlog.h
@@ -499,7 +499,7 @@ public:
     will be replaced with an id created by 
     ON_NextNotUniqueId(). 
     This is used for comparing code that generates streams
-    containg new uuids.
+    containing new uuids.
   */
   void SetIdRemap(
     bool bEnableIdRemap
@@ -515,7 +515,7 @@ public:
   Description:
     In some testing situations, the output text log can be set 
     when it is necessary to see the text used to compute the 
-    SHA-1 hash. The has can be caluculate which no output text
+    SHA-1 hash. The has can be calculate which no output text
     log.
 
   Parameters:

--- a/opennurbs_textobject.h
+++ b/opennurbs_textobject.h
@@ -106,7 +106,7 @@ public:
   /*
   Description:
   Transform the object by a 4x4 xform matrix and change text height
-  override to accomodate scaling in the transform if necessary
+  override to accommodate scaling in the transform if necessary
   Parameters:
   [in] xform  - An ON_Xform with the transformation information
   Returns:

--- a/opennurbs_texture.h
+++ b/opennurbs_texture.h
@@ -182,7 +182,7 @@ public:
   Parameters:
     dir - [in] 0 = reverse "u", 1 = reverse "v", 2 = reverse "w".
   Remarks:
-    Modifes m_uvw so that the spedified direction transforms
+    Modifies m_uvw so that the specified direction transforms
     the texture coordinate t to 1-t.
   Returns:
     True if input is valid.
@@ -196,7 +196,7 @@ public:
     i - [in]
     j - [in]  (0 <= i, j <= 3 and i != j)
   Remarks:
-    Modifes m_uvw so that the specified texture coordinates are swapped.
+    Modifies m_uvw so that the specified texture coordinates are swapped.
   Returns:
     True if input is valid.
   */
@@ -210,7 +210,7 @@ public:
     count - [in] number of tiles (can be negative)
     offset - [in] offset of the tile (can be any number)
   Remarks:
-    Modifes m_uvw so that the specified texture coordinate is
+    Modifies m_uvw so that the specified texture coordinate is
     tiled.
   Returns:
     True if input is valid.

--- a/opennurbs_texture_mapping.h
+++ b/opennurbs_texture_mapping.h
@@ -78,7 +78,7 @@ public:
     no_mapping       = 0,
     srfp_mapping     = 1, // u,v = linear transform of surface params,w = 0
     plane_mapping    = 2, // u,v,w = 3d coordinates wrt frame
-    cylinder_mapping = 3, // u,v,w = logitude, height, radius
+    cylinder_mapping = 3, // u,v,w = longitude, height, radius
     sphere_mapping   = 4, // (u,v,w) = longitude,latitude,radius
     box_mapping      = 5,
     mesh_mapping_primitive = 6, // m_mapping_primitive is an ON_Mesh 
@@ -291,7 +291,7 @@ public:
     sphere - [in]  
         sphere in world space used to define a spherical
         coordinate system. The longitude parameter maps
-        (0,2pi) to texture "u" (0,1).  The latitude paramter
+        (0,2pi) to texture "u" (0,1).  The latitude parameter
         maps (-pi/2,+pi/2) to texture "v" (0,1).
         The radial parameter maps (0,r) to texture "w" (0,1).
   Returns:
@@ -313,17 +313,17 @@ public:
        Determines the location of the front and back planes.
        The vector plane.xaxis is perpendicular to these planes
        and they pass through plane.PointAt(dx[0],0,0) and
-       plane.PointAt(dx[1],0,0), respectivly.
+       plane.PointAt(dx[1],0,0), respectively.
     dy - [in]
        Determines the location of the left and right planes.
        The vector plane.yaxis is perpendicular to these planes
        and they pass through plane.PointAt(0,dy[0],0) and
-       plane.PointAt(0,dy[1],0), respectivly.
+       plane.PointAt(0,dy[1],0), respectively.
     dz - [in] 
        Determines the location of the top and bottom planes.
        The vector plane.zaxis is perpendicular to these planes
        and they pass through plane.PointAt(0,0,dz[0]) and
-       plane.PointAt(0,0,dz[1]), respectivly.
+       plane.PointAt(0,0,dz[1]), respectively.
     bIsCapped - [in]
         If true, the box is treated as a finite
         capped box.          
@@ -463,7 +463,7 @@ public:
   Parameters:
     dir - [in] 0 = reverse "u", 1 = reverse "v", 2 = reverse "w".
   Remarks:
-    Modies m_uvw so that the spedified direction transforms
+    Modies m_uvw so that the specified direction transforms
     the texture coordinate t to 1-t.
   Returns:
     True if input is valid.

--- a/opennurbs_unicode.cpp
+++ b/opennurbs_unicode.cpp
@@ -724,7 +724,7 @@ int ON_DecodeUTF8(
     i0 = 1;
     if ( ON_IsValidUnicodeCodePoint(e->m_error_code_point) )
     {
-      // skip to next UTF-8 start elemement
+      // skip to next UTF-8 start element
       for ( /*empty for initializer*/; i0 < sUTF8_count; i0++ )
       {
         // Search for the next element of sUTF8[] that is the
@@ -793,7 +793,7 @@ int ON_DecodeUTF8(
 
 int ON_EncodeUTF16( ON__UINT32 unicode_code_point, ON__UINT16 sUTF16[2] )
 {
-  // put the most comman case first
+  // put the most common case first
   if ( unicode_code_point < 0xD800 )
   {
     // code point values U+0000 ... U+D7FF
@@ -3169,7 +3169,7 @@ unsigned ON_UnicodeSuperscriptFromCodePoint(
       0x1D3A, // N
       0x1D3C, // O
       0x1D3E, // P
-      0, // Q NOT AVIALABLE
+      0, // Q NOT AVAILABLE
       0x1D3F, // R
       0, // S NOT AVAILABLE
       0x1D40, // T
@@ -3205,7 +3205,7 @@ unsigned ON_UnicodeSuperscriptFromCodePoint(
     }
   }
 
-  // either cp is already a superscript or none is avilable.
+  // either cp is already a superscript or none is available.
   return no_superscript_cp;
 }
 
@@ -3282,7 +3282,7 @@ unsigned ON_UnicodeSubcriptFromCodePoint(
     }
   }
 
-  // either cp is already a subscript or none is avilable.
+  // either cp is already a subscript or none is available.
   return cp;
 }
 

--- a/opennurbs_unicode.h
+++ b/opennurbs_unicode.h
@@ -322,7 +322,7 @@ enum ON_UnicodeCodePoint
   /// byte order being used. It is valid for UTF-8 encoded text to begin
   /// with the UTF-8 encoding of U+FEFF (0xEF,0xBB,0xBF). 
   /// This sometimes used to mark a char string as UTF-8 encoded.
-  /// and also occures when UTF-16 and UTF-32 encoded text with a byte 
+  /// and also occurs when UTF-16 and UTF-32 encoded text with a byte 
   /// order mark is converted to UTF-8 encoded text.
   /// </summary>
   ON_ByteOrderMark = 0xFEFF,
@@ -386,12 +386,12 @@ Returns:
   ON_UTF_unset (0)
     buffer is not a UTF BOM
   ON_UTF_8
-    sizeof_buffer >= 3 and the values fo the first three bytes
+    sizeof_buffer >= 3 and the values of the first three bytes
     are 0xEF, 0xBB, 0xBF.
   ON_UTF_16BE
     sizeof_buffer >= 2 and the values of the first two bytes
     are 0xFE, 0xFF and, if sizeof_buffer >= 4, the value of
-    one of the thrid or forth byte is not zero.
+    one of the third or forth byte is not zero.
   ON_UTF_16LE
     sizeof_buffer >= 2 and the values of the first two bytes
     are 0xFE, 0xFF
@@ -618,13 +618,13 @@ struct ON_CLASS ON_UnicodeErrorParameters
 
   /*
   If an error occurs, then bits of error_status are
-  set to indicate what type of error occured.
+  set to indicate what type of error occurred.
 
   Error types:
     1: The input parameters were invalid. 
        This error cannot be masked.
 
-    2: The ouput buffer was not large enough to hold the converted
+    2: The output buffer was not large enough to hold the converted
        string. As much conversion as possible is performed in this
        case and the error cannot be masked.
 
@@ -645,7 +645,7 @@ struct ON_CLASS ON_UnicodeErrorParameters
        If the error is masked, then the unicode code point
        is used and parsing continues.
 
-   16: An illegal UTF-8, UTF-16 or UTF-32 sequence occured, 
+   16: An illegal UTF-8, UTF-16 or UTF-32 sequence occurred, 
       or an unsupported or invalid Windows code page value,      
       or an invalid unicode code point value resulted from 
       decoding a UTF-8 sequence. 
@@ -706,12 +706,12 @@ Returns:
      Nothing was decoded. The input value of *unicode_code_point
      is not changed.  See e->m_error_status.
   1: 
-     If no error occured, then sUTF32[0] was decoded was a valid 
+     If no error occurred, then sUTF32[0] was decoded was a valid 
      UTF-32 value. See e for masked errors.
   2:
       sUTF32[0],sUTF32[1] had values of a valid UTF-16 surrogate pair
       and e indicated to mask this error.  The UTF-16 code point
-      value was returned and e was set to indicate the error occured.
+      value was returned and e was set to indicate the error occurred.
 */
 ON_DECL
 int ON_DecodeUTF32LE(
@@ -753,12 +753,12 @@ Returns:
      Nothing was decoded. The input value of *unicode_code_point
      is not changed.  See e->m_error_status.
   1: 
-     If no error occured, then sUTF32[0] was decoded was a valid 
+     If no error occurred, then sUTF32[0] was decoded was a valid 
      UTF-32 value. See e for masked errors.
   2:
       sUTF32[0],sUTF32[1] had values of a valid UTF-16 surrogate pair
       and e indicated to mask this error.  The UTF-16 code point
-      value was returned and e was set to indicate the error occured.
+      value was returned and e was set to indicate the error occurred.
 */
 ON_DECL
 int ON_DecodeUTF32BE(
@@ -801,12 +801,12 @@ Returns:
      Nothing was decoded. The input value of *unicode_code_point
      is not changed.  See e->m_error_status.
   1: 
-     If no error occured, then sUTF32[0] was decoded was a valid 
+     If no error occurred, then sUTF32[0] was decoded was a valid 
      UTF-32 value. See e for masked errors.
   2:
       sUTF32[0],sUTF32[1] had values of a valid UTF-16 surrogate pair
       and e indicated to mask this error.  The UTF-16 code point
-      value was returned and e was set to indicate the error occured.
+      value was returned and e was set to indicate the error occurred.
 */
 ON_DECL
 int ON_DecodeUTF32(
@@ -850,12 +850,12 @@ Returns:
      Nothing was decoded. The input value of *unicode_code_point
      is not changed.  See e->m_error_status.
   1: 
-     If no error occured, then sUTF32[0] was decoded was a valid 
+     If no error occurred, then sUTF32[0] was decoded was a valid 
      UTF-32 value. See e for masked errors.
   2:
       sUTF32[0],sUTF32[1] had values of a valid UTF-16 surrogate pair
       and e indicated to mask this error.  The UTF-16 code point
-      value was returned and e was set to indicate the error occured.
+      value was returned and e was set to indicate the error occurred.
 */
 ON_DECL
 int ON_DecodeSwapByteUTF32(
@@ -873,7 +873,7 @@ Description:
   insuring the value of u is a valid uncode codepoint.
 Parameters:
   u - [in]
-    Interger in the CPU's native byte order in the interval [0,2147483647].
+    Integer in the CPU's native byte order in the interval [0,2147483647].
   sUTF8 - [out]
     sUTF8 is a buffer of 6 char elements and the UTF-8 form
     is returned in sUTF8[]. The returned value specifies how 
@@ -999,10 +999,10 @@ Returns:
      Nothing was decoded. The input value of *unicode_code_point
      is not changed.  See e->m_error_status.
   1: 
-     If no error occured, then sUTF16[0] was decoded as a valid 
+     If no error occurred, then sUTF16[0] was decoded as a valid 
      UTF-16 singleton. See e for masked errors.
   2: 
-     If no error occured, then sUTF16[0],sUTF16[1] was decoded 
+     If no error occurred, then sUTF16[0],sUTF16[1] was decoded 
      as a valid UTF-16 surrogate pair.
      See e for masked errors.
   n >= 3:
@@ -1050,10 +1050,10 @@ Returns:
      Nothing was decoded. The input value of *unicode_code_point
      is not changed.  See e->m_error_status.
   1: 
-     If no error occured, then sUTF16[0] was decoded as a valid 
+     If no error occurred, then sUTF16[0] was decoded as a valid 
      UTF-16 singleton. See e for masked errors.
   2: 
-     If no error occured, then sUTF16[0],sUTF16[1] was decoded 
+     If no error occurred, then sUTF16[0],sUTF16[1] was decoded 
      as a valid UTF-16 surrogate pair.
      See e for masked errors.
   n >= 3:
@@ -1101,10 +1101,10 @@ Returns:
      Nothing was decoded. The input value of *unicode_code_point
      is not changed.  See e->m_error_status.
   1: 
-     If no error occured, then sUTF16[0] was decoded as a valid 
+     If no error occurred, then sUTF16[0] was decoded as a valid 
      UTF-16 singleton. See e for masked errors.
   2: 
-     If no error occured, then sUTF16[0],sUTF16[1] was decoded 
+     If no error occurred, then sUTF16[0],sUTF16[1] was decoded 
      as a valid UTF-16 surrogate pair.
      See e for masked errors.
   n >= 3:
@@ -1154,10 +1154,10 @@ Returns:
      Nothing was decoded. The input value of *unicode_code_point
      is not changed.  See e->m_error_status.
   1: 
-     If no error occured, then sUTF16[0] was decoded as a valid 
+     If no error occurred, then sUTF16[0] was decoded as a valid 
      UTF-16 singleton. See e for masked errors.
   2: 
-     If no error occured, then sUTF16[0],sUTF16[1] was decoded 
+     If no error occurred, then sUTF16[0],sUTF16[1] was decoded 
      as a valid UTF-16 surrogate pair.
      See e for masked errors.
   n >= 3:
@@ -1206,10 +1206,10 @@ Returns:
      Nothing was decoded. The input value of *unicode_code_point
      is not changed.  See e->m_error_status.
   1: 
-     If no error occured, then sWideChar[0] was decoded as a valid 
+     If no error occurred, then sWideChar[0] was decoded as a valid 
      wchar_t singleton. See e for masked errors.
   n>=2: 
-     If no error occured, then sWideChar[0],..,sWideChar[n-1] was decoded 
+     If no error occurred, then sWideChar[0],..,sWideChar[n-1] was decoded 
      as a valid wchar_t multi-element encoding.
      Typically, UTF-16 surrogate pair or UTF-8 multi-byte sequence.
      See e for masked errors.
@@ -1230,7 +1230,7 @@ Description:
 
 Parameters:
   rtf_charset - [in]
-    The RTF charset specifed by /fcharsetN in the RTF font table.
+    The RTF charset specified by /fcharsetN in the RTF font table.
   default_code_page - [out]
     Value to return if none is associated with the input rtf_charset value.
 
@@ -1311,7 +1311,7 @@ Parameters:
   code_page - [in]
     A Microsoft single byte code page value. (1252, 10000, etc)
   code_page_single_byte_encoding - [in]
-    A single byte encoding of the desired glpyh.
+    A single byte encoding of the desired glyph.
 
 Returns:
   If cod page and code_page_single_byte_encoding are valid, then
@@ -1330,7 +1330,7 @@ Description:
   Windows code page 1252 is a single byte encoding.
   Values 0x20 to 0x7E are the same as the ASCII encoding.
 
-  This function is used to find fonts where glpyhs are identified by code page 1252 values.
+  This function is used to find fonts where glyphs are identified by code page 1252 values.
 
 Parameters:
   code_page - [in]
@@ -1452,7 +1452,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -1468,7 +1468,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -1590,7 +1590,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -1606,7 +1606,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -1727,7 +1727,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -1743,7 +1743,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -1877,7 +1877,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -1893,7 +1893,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -2017,7 +2017,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -2033,7 +2033,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -2168,7 +2168,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -2184,7 +2184,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -2318,7 +2318,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -2334,7 +2334,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -2468,7 +2468,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -2484,7 +2484,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -2624,7 +2624,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -2640,7 +2640,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -2688,7 +2688,7 @@ int ON_ConvertUTF32ToUTF32(
     int bTestByteOrder,
     const ON__UINT32* sInputUTF32,
     int sInputUTF32_count,
-    ON__UINT32* sOuputUTF32,
+    ON__UINT32* soutputUTF32,
     int sOutputUTF32_count,
     unsigned int* error_status,
     unsigned int error_mask,
@@ -2775,7 +2775,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -2791,7 +2791,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -2922,7 +2922,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -2938,7 +2938,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -3070,7 +3070,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -3086,7 +3086,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -3218,7 +3218,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -3234,7 +3234,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -3366,7 +3366,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -3382,7 +3382,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -3514,7 +3514,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
        4: When parsing a UTF-8 or UTF-32 string, the values of two
@@ -3530,7 +3530,7 @@ Parameters:
           This error is masked if 0 != (8 & m_error_mask).
           If the error is masked, then the unicode code point
           is used and parsing continues.
-      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occured
+      16: An illegal UTF-8, UTF-16 or UTF-32 encoding sequence occurred
           or an invalid unicode code point value resulted from decoding
           a UTF-8 sequence. 
           This error is masked if 0 != (16 & m_error_mask).
@@ -3606,7 +3606,7 @@ Description:
 
 Parameters:
   windows_code_page - [in]
-    THe windows code page specifices the encoding of the sMBCS string.
+    THe windows code page specifies the encoding of the sMBCS string.
 
   sMBCS - [in]
     Windows multibyte string with encoding identified by windows_code_page.
@@ -3641,7 +3641,7 @@ Parameters:
        0: Successful conversion with no errors.
        1: The input parameters were invalid. 
           This error cannot be masked.
-       2: The ouput buffer was not large enough to hold the converted
+       2: The output buffer was not large enough to hold the converted
           string. As much conversion as possible is performed in this
           case and the error cannot be masked.
       16: An illegal encoding sequence occurred.

--- a/opennurbs_unicode_cp932.cpp
+++ b/opennurbs_unicode_cp932.cpp
@@ -7006,7 +7006,7 @@ shift-JIS<SEP>JIS X 0208<SEP>UNICODE<SEP3>// name
 /*
 Description:
   Convert a Windows code page 932 encoded value to a UNICODE code point.
-  This code page is often used for Korean glpyhs.
+  This code page is often used for Korean glyphs.
 
 Parameters:
   code_page_932_character_value - [in]

--- a/opennurbs_units.cpp
+++ b/opennurbs_units.cpp
@@ -107,10 +107,10 @@ public:
     Parses m_name and sets the m_utf32_name[] and m_utf32_name_count
     fields.
   Returns:
-    Number of elments of m_name that were parsed; 0 indicates failure.
+    Number of elements of m_name that were parsed; 0 indicates failure.
   Remarks:
     m_name must contain a character that terminates unit system name parsing.
-    This can be a null, digit, punctuation, aritmetic operator, or a 
+    This can be a null, digit, punctuation, arithmetic operator, or a 
     unicode code point <= 0x0020 (0x0020 = space = 32 decimal).
   */
   int SetSimplifiedName();
@@ -382,8 +382,8 @@ static ON_UnitName en_US_customary_length_units[] =
 static ON_UnitName angle_no_units[] =
 {
   // These entries prevent parsing the strings unless an
-  // entry for a locale explicitly inludes the string and
-  // the parsing prefered local id matches exactly.
+  // entry for a locale explicitly includes the string and
+  // the parsing preferred local id matches exactly.
   // The purpose is to prevent incorrectly parsing strings
   // the define different unit systems in different 
   // locales.
@@ -1012,7 +1012,7 @@ static ON__UINT32 ON_ToLatinAtoZ( ON__UINT32 c )
   // It also converts sharp s (eszett) to latin letter S and 
   // greek tau to to latin letter T.
   //
-  // This code is designed to be used efficently parse common unit 
+  // This code is designed to be used efficiently parse common unit 
   // names in English, Spanish, French, German, Protuguese and Czech.
   // If other languages need to be supported, this function will need
   // to be enhanced, redone, or removed.  The unit names being parsed
@@ -1180,7 +1180,7 @@ Returns:
 
 Remarks:
   This code is used to quickly parse optional embedded unit
-  names, abreviations in input streams that specify angles,
+  names, abbreviations in input streams that specify angles,
   lengths, points in cartesian coordinates, and points in
   polar coordinates.  
   
@@ -1462,7 +1462,7 @@ static bool GetUnitSystemNameCache(
   // length_unit_list[].m_utf32_name_count increases.  
   // Use that fact to build an index based on the value of 
   // length_unit_list[].m_utf32_name_count so searches can
-  // easily be restriced to the region of length_unit_list[]
+  // easily be restricted to the region of length_unit_list[]
   // where a possible match exists.
   for ( i = 0; i < count; i++ )
   {
@@ -1690,7 +1690,7 @@ unsigned int GetLengthUnitList(
         }
         else
         {
-          ON_ERROR("Length unit list conatins invalid element.");
+          ON_ERROR("Length unit list contains invalid element.");
         }
       }
     }
@@ -1971,7 +1971,7 @@ static unsigned int GetAngleUnitList(
         }
         else
         {
-          ON_ERROR("Angle unit list conatins invalid element.");
+          ON_ERROR("Angle unit list contains invalid element.");
         }
       }
     }
@@ -2461,7 +2461,7 @@ int ON_LengthUnitName::Internal_Compare(
   i =  ON_wString::CompareOrdinal(a.m_name,b.m_name,false);
   if (i != 0)
   {
-    // ignore case order is prefered
+    // ignore case order is preferred
     j = ON_wString::CompareOrdinal(a.m_name, b.m_name, true);
     return (0 != j) ? j : i;
   }
@@ -2694,7 +2694,7 @@ int ON_AngleUnitName::Internal_Compare(
   i =  ON_wString::CompareOrdinal(a.m_name,b.m_name,false);
   if (i != 0)
   {
-    // ignore case order is prefered
+    // ignore case order is preferred
     j = ON_wString::CompareOrdinal(a.m_name, b.m_name, true);
     return (0 != j) ? j : i;
   }

--- a/opennurbs_userdata.cpp
+++ b/opennurbs_userdata.cpp
@@ -544,7 +544,7 @@ ON_UserData* ON_UnknownUserData::Convert() const
   ON_UserData* ud = nullptr;
   if ( IsValid() ) {
     const ON_ClassId* pID = ON_ClassId::ClassId( m_unknownclass_uuid );
-    // if pID is nullptr, it means the definiton of the unknown user data
+    // if pID is nullptr, it means the definition of the unknown user data
     // is still not available
     if ( pID ) {
       // The class definition has been dynamically loaded since the
@@ -890,7 +890,7 @@ static int cmp_hash_2dex_ij(const void* a, const void* b)
   //    The "i" values are actually 32 bit hashes of a string
   //    and are often large.  The sign of (ai[0] - bi[0]) cannot
   //    be used to compare ai[0] and bi[0] because integer
-  //    overflow occures with values that are large.
+  //    overflow occurs with values that are large.
   //
   ////// NO!
   //////if ( 0 == (rc = ai[0] - bi[0]) )

--- a/opennurbs_userdata.h
+++ b/opennurbs_userdata.h
@@ -155,10 +155,10 @@ public:
       archive that will be written to.  
       If needed, you can inspect the version of 3dm archive this
       is being saved and other information that you may need to 
-      determine the approprite return value.
+      determine the appropriate return value.
     parent_object - [in]
       If needed, you can inspect the parent object to determine 
-      the approprite return value.
+      the appropriate return value.
 
   Returns:
     True if the user data should be written the next
@@ -198,10 +198,10 @@ public:
       archive that was read from.
       If needed, you can inspect the version of 3dm archive this
       is being saved and other information that you may need to
-      determine the approprite return value.
+      determine the appropriate return value.
     parent_object - [in]
       If needed, you can inspect the parent object to determine
-      the approprite return value.
+      the appropriate return value.
 
   Returns:
     True if the user data should be deleted because the 
@@ -349,7 +349,7 @@ public:
 };
 
 // Do not export this class
-// It is used internally to read and write 3dm achives with versions < 60.
+// It is used internally to read and write 3dm archives with versions < 60.
 class ON_RdkMaterialInstanceIdObsoleteUserData : public ON_ObsoleteUserData
 {
   // NO ON_OBJECT_DECLARE() for classes derived from ON_ObsoleteUserData

--- a/opennurbs_userdata_obsolete.cpp
+++ b/opennurbs_userdata_obsolete.cpp
@@ -37,7 +37,7 @@ static bool ON_Internal_ReadObsoleteUserDataAnonymouseChunk(ON_BinaryArchive& ar
 {
   // If the obsolete user data's Write()/Read() function wrapped all the contents in
   // an anonymous chunk (which is the suggested best practice), then
-  // this skip over everthing in the chunk and not generate any file read warnings or errors.
+  // this skip over everything in the chunk and not generate any file read warnings or errors.
   int major_version = 0;
   int minor_version = 0;
   bool rc = archive.BeginRead3dmChunk(TCODE_ANONYMOUS_CHUNK,&major_version,&minor_version);

--- a/opennurbs_uuid.cpp
+++ b/opennurbs_uuid.cpp
@@ -80,7 +80,7 @@ static const ON_UUID ON_Internal_CreateNotUniqueSequentialId(
   //
   // It is based on the MAC address of a network card that
   // was destroyed circa 2000. The Time portion of the UUID is generated
-  // from index_64_bit and will generall be well before the current time.
+  // from index_64_bit and will generally be well before the current time.
   // The reason for using this complicated approach is to insure
   // data structures usisg these i values will pass validty checking
   // that tests to see if the UUID has a valid format.

--- a/opennurbs_uuid.h
+++ b/opennurbs_uuid.h
@@ -464,7 +464,7 @@ Parameters:
   s - [in]
 Returns:
   uuid.  
-  If the string is not a uuid, then ON_nil_uuid is returnd.
+  If the string is not a uuid, then ON_nil_uuid is returned.
 */
 ON_DECL 
 ON_UUID ON_UuidFromString( const char* s );
@@ -481,7 +481,7 @@ Parameters:
   s - [in]
 Returns:
   uuid.  
-  If the string is not a uuid, then ON_nil_uuid is returnd.
+  If the string is not a uuid, then ON_nil_uuid is returned.
 */
 ON_DECL 
 ON_UUID ON_UuidFromString( const wchar_t* s );
@@ -522,7 +522,7 @@ Description:
   Parses a string like "85a08515-f383-11d3-bfe7-0010830122f0" 
   and returns the value as a uuid. Hyphens can appear anywhere
   and are ignored. Parsing stops at any character that is not
-  a hexidecimal digit or hyphen.  Parsing stops after 32 hexidecimal
+  a hexadecimal digit or hyphen.  Parsing stops after 32 hexadecimal
   digits are read;
 Parameters:
   sUuid - [in]

--- a/opennurbs_version.h
+++ b/opennurbs_version.h
@@ -219,7 +219,7 @@
 //  October 23 1019, Rhino 7 WIP writes version 7 files.
 //
 // More generally, in a stable release product, OPENNURBS_CURRENT_ARCHIVE_VERSION = OPENNURBS_VERSION_MAJOR*10.
-// But for some period of time at the beginning of the Rhino (N+1) WIP developement cycle,
+// But for some period of time at the beginning of the Rhino (N+1) WIP development cycle,
 // Rhino (N+1) WIP writes Rhino N files. That's why OPENNURBS_CURRENT_ARCHIVE_VERSION
 // is sometimes (OPENNURBS_VERSION_MAJOR*10) and is sometimes ((OPENNURBS_VERSION_MAJOR-1)*10)
 #define OPENNURBS_CURRENT_ARCHIVE_VERSION 70

--- a/opennurbs_version_number.cpp
+++ b/opennurbs_version_number.cpp
@@ -160,7 +160,7 @@ bool ON_VersionNumberIsYearMonthDateFormat(
 {
   // Note: 
   //   When new versions of opennurbs save V2,V3,V4 or V5 files,
-  //   they have to write old yyyymmddn verison numbers so the
+  //   they have to write old yyyymmddn version numbers so the
   //   old code will read the file.  In this case, n = 6,7,8,9.
   //   (n=9 meant debug prior to 2014);
   //

--- a/opennurbs_version_number.h
+++ b/opennurbs_version_number.h
@@ -19,7 +19,7 @@
 
 /*
 Description:
-  Create a 4-byte unsigned integer value that has desireable version 
+  Create a 4-byte unsigned integer value that has desirable version 
   number properties.
 
 Parameters:

--- a/opennurbs_viewport.cpp
+++ b/opennurbs_viewport.cpp
@@ -1068,7 +1068,7 @@ bool ON_Viewport::SetCameraFrame()
   if ( !CamX.Unitize() )
     return false; // happens when up and dir are temporaily parallel.
 
-  // Gaurd against garbage resulting from nearly parallel 
+  // Guard against garbage resulting from nearly parallel 
   // and/or ultra short short dir and up.
   if ( !ON__IsCameraFrameUnitVectorHelper(CamX) )
     return Internal_SetCameraFameFailed();
@@ -2168,7 +2168,7 @@ INPUT:
   //
   //   target, angle1, angle2, angle3, viewsize, and cameradist.
   //
-  // The width, height and zbuffer_depth arguments are used to determing the
+  // The width, height and zbuffer_depth arguments are used to determine the
   // clipping to screen transformation.
 
   ON_Xform R1, R2, R3, RhinoRot;
@@ -2188,7 +2188,7 @@ INPUT:
   // A Rhino 1.0 VIEWPORT structure describes the camera's location, direction,
   // and  orientation by specifying a rotation transformation that is
   // applied to an initial frame.  The rotation transformation is defined
-  // as a sequence of 3 rotations abount fixed axes.  The initial frame
+  // as a sequence of 3 rotations around fixed axes.  The initial frame
   // has the camera located at (0,0,cameradist), pointed in the direction
   // (0,0,-1), and oriented so that up is (0,1,0).
 
@@ -2221,7 +2221,7 @@ INPUT:
   // Rhino 1.0 didn't have a far clipping plane in wire frame (which explains
   // why you can get perspective views reversed through the origin by using 
   // the SetCameraTarget() command.  It's near clipping plane is set to 
-  // a miniscule value.  For mesh rendering, it must come up with some
+  // a minuscule value.  For mesh rendering, it must come up with some
   // sort of reasonable near and far clipping planes because the zbuffer
   // is used correctly.  When time permits, I'll dig through the rendering
   // code and determine what values are being used.
@@ -2257,7 +2257,7 @@ INPUT:
          near_clipping_distance, far_clipping_distance );
 
   // Windows specific stuff that requires knowing size of client area in pixels
-  vp.SetScreenPort( 0, (int)width, // windows has screen X increasing accross
+  vp.SetScreenPort( 0, (int)width, // windows has screen X increasing across
                     (int)height,  0, // windows has screen Y increasing downwards
                     0, 0xFFFF );
 
@@ -2795,10 +2795,10 @@ bool ON_Viewport::ChangeToSymmetricFrustum(
     )
 {
   if ( bLeftRightSymmetric && m_frus_left == -m_frus_right )
-    bLeftRightSymmetric = false; // no left/right chnages required.
+    bLeftRightSymmetric = false; // no left/right changes required.
 
   if ( bTopBottomSymmetric && m_frus_bottom == -m_frus_top )
-    bTopBottomSymmetric = false; // no top/bottom chagnes required.
+    bTopBottomSymmetric = false; // no top/bottom changes required.
 
   if ( !bLeftRightSymmetric && !bTopBottomSymmetric )
     return true; // no changes required
@@ -3480,7 +3480,7 @@ int ON_Viewport::GetBoundingBoxDepth(
       Pin |= k;
       if ( (1|2|4|8|16) == k )
       {
-        // C[i] is inside the infinte frustum
+        // C[i] is inside the infinite frustum
         P[Pcount++] = C[i];
       }
     }
@@ -3488,7 +3488,7 @@ int ON_Viewport::GetBoundingBoxDepth(
     if ( Pcount < 8 )
     {
       bTrimmed = true;
-      // some portion of bbox is outside the infinte frustum
+      // some portion of bbox is outside the infinite frustum
       if ( (1|2|4|8|16) != Pin )
       {
         // bbox does not intersect the infinite frustum.
@@ -3628,7 +3628,7 @@ int ON_Viewport::GetBoundingBoxDepth(
     break;
   }
 
-  // 0 = out, 1 = partially in infinte frustum, 2 = all in infinte frustum
+  // 0 = out, 1 = partially in infinite frustum, 2 = all in infinite frustum
   return (rc) ? (bTrimmed ? 1 : 2) : 0;
 }
 
@@ -4428,7 +4428,7 @@ bool ON_Viewport::SetViewScale( double x, double y )
   //   frustum left/right top/bottom but I was stupid and added a clipmodxform 
   //   that is more trouble than it is worth.
   //   Someday I will fix this.  In the mean time, I want all scaling requests
-  //   to flow through SetViewScale/GetViewScale so I can easly find and fix
+  //   to flow through SetViewScale/GetViewScale so I can easily find and fix
   //   things when I have time to do it right.
   // 04 November 2011 S. Baer (RR93636)
   //   This function is used for printer calibration and it is commonly possible
@@ -4470,7 +4470,7 @@ double ON_Viewport::ClipCoordDepthBias( double relative_depth_bias, double clip_
   {
     if ( ON::perspective_view == m_projection )
     {
-      // To get the formula for the code in this claus:
+      // To get the formula for the code in this clause:
       //
       // Set M = [Camera2Clip]*[translation by (0,0,relative_depth_bias*(f-n)]*[Clip2Camera]
       // Note that M maps clipping coordinates to clipping coordinates.
@@ -4824,7 +4824,7 @@ bool ON_IntersectViewFrustumPlane(
   }
 
   // sort points by the angle (ppt_list[i].m_Q = ppt_list[0].m_Q) makes
-  // with the positve x axis.  This is the same as sorting them by
+  // with the positive x axis.  This is the same as sorting them by
   // -cot(angle) = -deltax/deltay.
   ppt_list[0].m_negcotangle = -ON_DBL_MAX; // -cot(0) = - infinity
   for ( i = 1; i < ppt_count; i++ )
@@ -4910,7 +4910,7 @@ void ON_Viewport::GetPerspectiveClippingPlaneConstraints(
     //   generating clipping artifacts in the perspective
     //   view in bug report 88216.  Changing to
     //   to the code below gets rid of those
-    //   artifacts at the risk of having a meaninless
+    //   artifacts at the risk of having a meaningless
     //   view to clip transform if the transformation is
     //   calculated with single precision numbers.
     //   If these values require further tuning, please

--- a/opennurbs_viewport.h
+++ b/opennurbs_viewport.h
@@ -139,7 +139,7 @@ public:
     ) const override;
 
   // Description:
-  //   Writes ON_Viewport defintion from a binary archive.
+  //   Writes ON_Viewport definition from a binary archive.
   //
   // Parameters:
   //   binary_archive - [in] open binary archive
@@ -155,7 +155,7 @@ public:
 
 
   // Description:
-  //   Reads ON_Viewport defintion from a binary archive.
+  //   Reads ON_Viewport definition from a binary archive.
   //
   // Parameters:
   //   binary_archive - [in] open binary archive
@@ -252,7 +252,7 @@ public:
     target_distance - [in]
       If ON_UNSET_VALUE this parameter is ignored.  Otherwise
       it must be > 0 and indicates which plane in the current 
-      view frustum should be perserved.
+      view frustum should be preserved.
     bSymmetricFrustum - [in]
       True if you want the resulting frustum to be symmetric.
     lens_length - [in] (pass 50.0 when in doubt)
@@ -281,7 +281,7 @@ public:
     target_distance - [in]
       If ON_UNSET_VALUE this parameter is ignored.  Otherwise
       it must be > 0 and indicates which plane in the current 
-      view frustum should be perserved.
+      view frustum should be preserved.
     up - [in]
       This direction will be the locked up direction.  Pass 
       ON_3dVector::ZeroVector if you want to use the world axis
@@ -459,7 +459,7 @@ public:
   );
 
 
-  // SetFrustumAspect() changes the larger of the frustum's widht/height
+  // SetFrustumAspect() changes the larger of the frustum's width/height
   // so that the resulting value of width/height matches the requested
   // aspect.  The camera angle is not changed.  If you change the shape
   // of the view port with a call SetScreenPort(), then you generally 
@@ -626,7 +626,7 @@ public:
     projection, the it intersects the semi infinite frustum
     volume with the bounding box and returns the near and far
     distances of the intersection.  If the viewport is a parallel
-    projection, it instersects the infinte view region with the
+    projection, it instersects the infinite view region with the
     bounding box and returns the near and far distances of the
     projection.
   */
@@ -671,7 +671,7 @@ public:
     projection, the it intersects the semi infinite frustum
     volume with the bounding box and returns the near and far
     distances of the intersection.  If the viewport is a parallel
-    projection, it instersects the infinte view region with the
+    projection, it instersects the infinite view region with the
     bounding box and returns the near and far distances of the
     projection.
   */
@@ -1768,10 +1768,10 @@ ON_ViewportFromRhinoView( // create ON_Viewport from legacy Rhino projection inf
 /*
 Description:
   Calculate the corners of the polygon that is the
-  intersection of a view frustum with and infinte plane.
+  intersection of a view frustum with and infinite plane.
 Parameters:
   vp - [in] defines view frustum
-  plane_equation - [in] defined infinte plane
+  plane_equation - [in] defined infinite plane
   points  - [out] corners of the polygon.
     If true is returned and points.Count() is zero, then
     the plane missed the frustum.  Note that the start/end

--- a/opennurbs_win_dwrite.cpp
+++ b/opennurbs_win_dwrite.cpp
@@ -541,13 +541,13 @@ void ON_Font::DumpWindowsDWriteFont(
     Internal_DWriteFontInformation(DWRITE_INFORMATIONAL_STRING_VERSION_STRINGS,L"DWrite field 5 version"),
     Internal_DWriteFontInformation(DWRITE_INFORMATIONAL_STRING_TRADEMARK,L"DWrite field 7 trademark"),
     Internal_DWriteFontInformation(DWRITE_INFORMATIONAL_STRING_MANUFACTURER,L"DWrite field 8 manufacturer"),
-    Internal_DWriteFontInformation(DWRITE_INFORMATIONAL_STRING_DESIGNER,L"DWrite field 9 designer/foundary"),
+    Internal_DWriteFontInformation(DWRITE_INFORMATIONAL_STRING_DESIGNER,L"DWrite field 9 designer/foundry"),
 
     // DWRITE_INFORMATIONAL_STRING_DESCRIPTION gets field 10 from the ttf file.
     // Opennurbs searches the description saved in field 10 of the name table
     // for the strings "Engraving - single stroke" / "Engraving - double stroke" / "Engraving"
     // to identify fonts that are desgned for engraving (and which tend to render poorly when
-    // used to dispaly text devices like screens, monitors, and printers).
+    // used to display text devices like screens, monitors, and printers).
     // The SLF (single line fonts) are examples of fonts that have Engraving in field 10.
     Internal_DWriteFontInformation(DWRITE_INFORMATIONAL_STRING_DESCRIPTION,L"DWrite field 10 description"),
 
@@ -575,7 +575,7 @@ void ON_Font::DumpWindowsDWriteFont(
   // Opennurbs searches the description saved in field 10 of the name table
   // for the strings "Engraving - single stroke" / "Engraving - double stroke" / "Engraving"
   // to identify fonts that are desgned for engraving (and which tend to render poorly when
-  // used to dispaly text devices like screens, monitors, and printers).
+  // used to display text devices like screens, monitors, and printers).
   // The SLF (single line fonts) are examples of fonts that have Engraving in field 10.
   const ON_wString field_10_description = ON_Font::Field_10_DescriptionFromWindowsDWriteFont(dwrite_font, preferedLocale);
   text_log.Print(L"ON_Font field 10 description = \"%ls\"\n", static_cast<const wchar_t*>(field_10_description));
@@ -810,11 +810,11 @@ const ON_wString ON_Font::Field_9_DesignerFromWindowsDWriteFont(
   return Internal_InfoStringFromWindowsDWriteFont(dwrite_font, DWRITE_INFORMATIONAL_STRING_DESIGNER, preferedLocale);
 }
 
-// Returns the desription saved in field 10. 
+// Returns the description saved in field 10. 
 // Opennurbs searches the description saved in field 10 of the name table
 // for the strings "Engraving - single stroke" / "Engraving - double stroke" / "Engraving"
 // to identify fonts that are desgned for engraving (and which tend to render poorly when
-// used to dispaly text devices like screens, monitors, and printers).
+// used to display text devices like screens, monitors, and printers).
 // The SLF (single line fonts) are examples of fonts that have Engraving in field 10.
 const ON_wString ON_Font::Field_10_DescriptionFromWindowsDWriteFont(
   struct IDWriteFont* dwrite_font,
@@ -877,7 +877,7 @@ void ON_WindowsDWriteFontInformation::Dump(ON_TextLog& text_log) const
   if ( bVerbose )
   {
     if (m_prefered_locale.IsNotEmpty())
-      text_log.Print("Prefered locale = \"%ls\"\n", static_cast<const wchar_t*>(m_prefered_locale));
+      text_log.Print("Preferred locale = \"%ls\"\n", static_cast<const wchar_t*>(m_prefered_locale));
     if (FamilyName().IsNotEmpty())
     {
       if (FaceName().IsNotEmpty())
@@ -1358,7 +1358,7 @@ unsigned int ON_Font::GetInstalledWindowsDWriteFonts(
         // Opennurbs searches the description saved in field 10 of the name table
         // for the strings "Engraving - single stroke" / "Engraving - double stroke" / "Engraving"
         // to identify fonts that are desgned for engraving (and which tend to render poorly when
-        // used to dispaly text devices like screens, monitors, and printers).
+        // used to display text devices like screens, monitors, and printers).
         // The SLF (single line fonts) are examples of fonts that have Engraving in field 10.
         fi.m_loc_field_10_description = ON_Font::Field_10_DescriptionFromWindowsDWriteFont(dwriteFont.Get(), preferedLocale);
         fi.m_en_field_10_description = ON_Font::Field_10_DescriptionFromWindowsDWriteFont(dwriteFont.Get(), englishLocale);
@@ -1404,7 +1404,7 @@ unsigned int ON_Font::GetInstalledWindowsDWriteFonts(
 
         if (0 == fi.m_gdi_interop_logfont.lfFaceName[0])
         {
-          // During testing on Windows 10, this never occured.
+          // During testing on Windows 10, this never occurred.
           // ...
           // Dale Lear 7 Jan 2019.
           // It appears Turbo Tax 2018 installs 4 faces of Avenir LT with
@@ -2192,7 +2192,7 @@ bool ON_Font::SetFromWindowsDWriteFont(
     // Opennurbs searches the description saved in field 10 of the name table
     // for the strings "Engraving - single stroke" / "Engraving - double stroke" / "Engraving"
     // to identify fonts that are desgned for engraving (and which tend to render poorly when
-    // used to dispaly text devices like screens, monitors, and printers).
+    // used to display text devices like screens, monitors, and printers).
     // The SLF (single line fonts) are examples of fonts that have Engraving in field 10.
     ON_wString loc_field_10_description = ON_Font::Field_10_DescriptionFromWindowsDWriteFont(dwrite_font, preferedLocale);
     ON_wString en_field_10_description = ON_Font::Field_10_DescriptionFromWindowsDWriteFont(dwrite_font, L"en-us");
@@ -2219,7 +2219,7 @@ bool ON_Font::SetFromWindowsDWriteFont(
       m_outline_figure_type = ON_OutlineFigure::FigureTypeFromFontName(m_en_family_name);
 
     // If it's still unset, we won't do any better in the future,
-    // so set m_outline_figure_type to unknow.
+    // so set m_outline_figure_type to unknown.
     if (ON_OutlineFigure::Type::Unset == m_outline_figure_type)
       m_outline_figure_type = ON_OutlineFigure::Type::Unknown;
 

--- a/opennurbs_wstring.cpp
+++ b/opennurbs_wstring.cpp
@@ -235,7 +235,7 @@ bool ON_wString::IsValid(
     return true;
   for (;;)
   {
-    // These checks attempt to detect cases when the memory used for the header informtion
+    // These checks attempt to detect cases when the memory used for the header information
     // no longer contains valid settings.
     const wchar_t* s = m_s;
     if (nullptr == s)
@@ -296,8 +296,8 @@ bool ON_wString::IsValid(
     {
       // Because the ON_wString m_s[] array can have internal null elements,
       // the length test has to be enabled in situations where it is certain
-      // that we are in the common situation where m_s[] is a single null teminated 
-      // sting and hdr->string_length is the m_s[] index of the null terminator.
+      // that we are in the common situation where m_s[] is a single null terminated 
+      // string and hdr->string_length is the m_s[] index of the null terminator.
       while (s < s1 && 0 != *s)
         s++;
       if (s != s1)
@@ -310,7 +310,7 @@ bool ON_wString::IsValid(
   // prevent imminent and unpredictable crash
   //
   // The empty string is used (as opposed to something like "YIKES - CALL TECH SUPPORT")
-  // becuase anything besides the empty string introduces using heap in a class that
+  // because anything besides the empty string introduces using heap in a class that
   // has been corrupted by some earlier operation.
   const_cast<ON_wString*>(this)->m_s = (wchar_t*)pEmptywString;
   // Devs
@@ -521,7 +521,7 @@ void ON_wString::CopyToArray( int size, const char* s )
       break;
     // s = UTF-8 string.
     // m_s = UTF-8, UTF-16, or UTF-32 encoded string.
-    // Even with errors, the number of wchar_t elments <= UTF-8 length
+    // Even with errors, the number of wchar_t elements <= UTF-8 length
     Header()->string_length = c2w( size, s, Header()->string_capacity, m_s );
     m_s[Header()->string_length] = 0;
     return;

--- a/opennurbs_xform.cpp
+++ b/opennurbs_xform.cpp
@@ -1246,11 +1246,11 @@ int ON_Xform::IsSimilarity() const
 
 int ON_Xform::IsSimilarity(double tol) const
 {
-	// This function does not construt a similarity transformation,  
-	// ( see ON_Xform::DecomposeSimilarity() for this ).  It mearly 
+	// This function does not construct a similarity transformation,  
+	// ( see ON_Xform::DecomposeSimilarity() for this ).  It merely 
 	// indicates that this transformation is sufficiently close to a similatiry.
 	// However using with a tight tolerance like tol<ON_ZERO_TOLERANCE 
-	// Indicates that this is very close to being a similar tranformation.
+	// Indicates that this is very close to being a similar transformation.
 	// This calculations is based on approximations and is only  
 	// reliable if tolerance << 1.0. 
 	int rval = 0;
@@ -1287,7 +1287,7 @@ int ON_Xform::DecomposeSimilarity(ON_3dVector& T, double& dilation, ON_Xform& R,
 		/* Three cases:
 		I. L is within OrthogonalTol of being orthogonal then just return R = Linear
 		(this is an optimization to avoid doing an eigen solve)
-		II. Linear<10*tolerance or tol>1.0 then find the closest orthogonal matix R.
+		II. Linear<10*tolerance or tol>1.0 then find the closest orthogonal matrix R.
 		test the final solution to see if |*this-R|<tolerance .
 		III. Otherwise return 0
 		*/
@@ -1385,7 +1385,7 @@ int ON_Xform::DecomposeRigid(ON_3dVector& T,  ON_Xform& R, double tolerance) con
 		/* Three cases:
 			I. Linear is within OrthogonalTol of being orthogonal then just return R = Linear
 				  (this is an optimization to avoid doing an eigen solve)
-			II. Linear~~<10*tolerance or tol>1.0 then find the closest orthogonal matix R.
+			II. Linear~~<10*tolerance or tol>1.0 then find the closest orthogonal matrix R.
 					test the final solution to see if |*this-R|<tolerance .
 			III. Otherwise return 0
 
@@ -1435,11 +1435,11 @@ int ON_Xform::DecomposeRigid(ON_3dVector& T,  ON_Xform& R, double tolerance) con
 
 int ON_Xform::IsRigid(double tolerance) const
 { 
-	// This function does not construt a rigid transformation,  
-	// ( see ON_Xform::DecomposeRigid() for this ).  It mearly 
-	// indicates that this trasformation is sufficiently close to a rigid one.
+	// This function does not construct a rigid transformation,  
+	// ( see ON_Xform::DecomposeRigid() for this ).  It merely 
+	// indicates that this transformation is sufficiently close to a rigid one.
 	// However using with a tight tolerance like tol<ON_ZERO_TOLERANCE 
-	// Indicates that this is very close to being a rigid tranformation.
+	// Indicates that this is very close to being a rigid transformation.
 	// This calculations is based on approximations and is only  
 	// reliable if tolerance << 1.0. 
 	int rval = 0;
@@ -1614,7 +1614,7 @@ bool ON_Xform::DecomposeAffine(ON_Xform& L, ON_3dVector& T) const
 			L[0][3] = L[1][3] = L[2][3] = 0.0;
 		}
 		/*
-			TODO: A more thourough solution would be to take a tolerance and
+			TODO: A more thorough solution would be to take a tolerance and
 			compute the best approximate T using psuodoinvese and comparing it
 			using the tolerance.
 		*/

--- a/opennurbs_xform.h
+++ b/opennurbs_xform.h
@@ -315,7 +315,7 @@ public:
 		DecomposeAffine(L, T), on the otherhand, may fail for affine transformations if L is not invertible
 		and is more computationally expensive.
 	Returns:
-		True - if sucessfull decomposition
+		True - if successful decomposition
 	*/
 	bool IsAffine() const;
 	bool IsLinear() const;
@@ -420,7 +420,7 @@ public:
     When transforming 3d point and surface or mesh normals
     two different transforms must be used.
     If P_xform transforms the point, then the inverse
-    transpose of P_xform must be used to tranform normal
+    transpose of P_xform must be used to transform normal
     vectors.
   Parameters:
     N_xform - [out]
@@ -656,7 +656,7 @@ public:
   // Parameters:
   //   plane - [in] plane to project to
   // Remarks:
-  //   This transformaton maps a 3d point P to the
+  //   This transformation maps a 3d point P to the
   //   point plane.ClosestPointTo(Q).
   void PlanarProjection(
     const ON_Plane& plane
@@ -858,7 +858,7 @@ Notes:
   //   ways to compute a change of basis transformation.
   //
   // Parameters:
-  //   plane0 - inital plane
+  //   plane0 - initial plane
   //   plane1 - final plane
   //
   // Returns:
@@ -1278,7 +1278,7 @@ public:
   Description:
     The "visible area" is the intersection of the view frustum,
     defined by m_xform, and the clipping region, defined by the
-    m_clip_plane[] array.  These functions determing if some
+    m_clip_plane[] array.  These functions determine if some
     portion of the convex hull of the test points is visible.
   Parameters:
     P - [in] point
@@ -1311,7 +1311,7 @@ public:
 
   /*
   Description:
-    Transform a list of 4d homogenous points while testing
+    Transform a list of 4d homogeneous points while testing
     for visibility.
   Parameters:
     count - [in] number of points
@@ -1322,7 +1322,7 @@ public:
     pflags - [out]
           0 when the point is in the visible region.  
           Otherwise the bits are set to indicate which planes clip the
-          intput point.
+          input point.
           0x01 left of the view frusturm
           0x02 right of the view frustum
           0x04 below the view frustum
@@ -1352,14 +1352,14 @@ public:
 
   /*
   Description:
-    Transform a pont and return the clipping information.
+    Transform a point and return the clipping information.
   Parameters:
     P - [in] point ot transform
     Q - [out] transformed point
   Returns:
     0 when the point is in the visible region.  
     Otherwise the bits are set to indicate which planes clip the
-    intput point.
+    input point.
     0x01 left of the view frusturm
     0x02 right of the view frustum
     0x04 below the view frustum
@@ -1441,7 +1441,7 @@ public:
 
   /*
   Description:
-    Sets point count and aggragate flags falues to zero but does not 
+    Sets point count and aggregate flags falues to zero but does not 
     deallocate the memory buffer.  When an ON_ClippingRegionPoints will be used
     multiple times, it is more efficient to call Clear() between
     uses than calling Destroy().
@@ -1557,7 +1557,7 @@ private:
 
 #pragma region
 /// <summary>
-/// ON_PickType specifies what type of pick is occuring.
+/// ON_PickType specifies what type of pick is occurring.
 /// </summary>
 enum class ON_PickType : unsigned char
 {
@@ -1649,7 +1649,7 @@ public:
   bool Write(ON_BinaryArchive&) const;
 
   /*
-  Descrption:
+  Description:
     Creates a cylindrical localizer.
     If d = distance from the point to the line, 
     then the localizer has the following behavior:
@@ -1667,7 +1667,7 @@ public:
     r0 - [in]
     r1 - [in]
       r0 and r1 are radii that control where the localizer is nonzero.  
-      Both r0 and r1 must be postive and the cannot be equal.  
+      Both r0 and r1 must be positive and the cannot be equal.  
       If 0 < r0 < r1, then the localizer is zero for points 
       inside the cylinder of radius r0 and one for points outside
       the cylinder of radius r1.
@@ -1681,7 +1681,7 @@ public:
   bool CreateCylinderLocalizer( ON_3dPoint P, ON_3dVector D, double r0, double r1 );
 
   /*
-  Descrption:
+  Description:
     Creates a planar localizer.
     If d = signed distance from the point to the plane,
     then the localizer has the following behavior:
@@ -1707,7 +1707,7 @@ public:
   bool CreatePlaneLocalizer( ON_3dPoint P, ON_3dVector N, double h0, double h1 );
 
   /*
-  Descrption:
+  Description:
     Creates a spherical localizer.
     If d = distance from the point to the center of the sphere, 
     then the localizer has the following behavior:
@@ -1724,7 +1724,7 @@ public:
     r0 - [in]
     r1 - [in]
       r0 and r1 are radii that control where the localizer is nonzero.  
-      Both r0 and r1 must be postive and the cannot be equal.  
+      Both r0 and r1 must be positive and the cannot be equal.  
       If 0 < r0 < r1, then the localizer is zero for points 
       inside the cylinder of radius r0 and one for points outside
       the cylinder of radius r1.

--- a/opennurbs_zlib.cpp
+++ b/opennurbs_zlib.cpp
@@ -297,7 +297,7 @@ size_t ON_BinaryArchive::WriteDeflate( // returns number of bytes written
   m_zlib.m_strm.next_out = m_zlib.m_buffer;
   m_zlib.m_strm.avail_out = m_zlib.sizeof_x_buffer;
 
-  // counter guards prevents infinte loops if there is a bug in zlib return codes.
+  // counter guards prevents infinite loops if there is a bug in zlib return codes.
   int counter = 512; 
   int flush = Z_NO_FLUSH;
 
@@ -498,7 +498,7 @@ bool ON_BinaryArchive::ReadInflate(
   my_next_out  += d;
   my_avail_out -= d;
 
-  // counter guards against infinte loop if there are
+  // counter guards against infinite loop if there are
   // bugs in zlib return codes
   int counter = 512;
   int flush = Z_NO_FLUSH;
@@ -1167,7 +1167,7 @@ size_t ON_CompressedBuffer::DeflateHelper( // returns number of bytes written
   m_zlib.m_strm.next_out = m_zlib.m_buffer;
   m_zlib.m_strm.avail_out = m_zlib.sizeof_x_buffer;
 
-  // counter guards prevents infinte loops if there is a bug in zlib return codes.
+  // counter guards prevents infinite loops if there is a bug in zlib return codes.
   int counter = 512; 
   int flush = Z_NO_FLUSH;
 
@@ -1301,7 +1301,7 @@ bool ON_CompressedBuffer::InflateHelper(
   my_next_out  += d;
   my_avail_out -= d;
 
-  // counter guards against infinte loop if there are
+  // counter guards against infinite loop if there are
   // bugs in zlib return codes
   int counter = 512;
   int flush = Z_NO_FLUSH;

--- a/opennurbs_zlib.h
+++ b/opennurbs_zlib.h
@@ -35,7 +35,7 @@
 #endif
 
 #if !defined(MY_ZCALLOC)
-/* have zlib use oncalloc() and onfree() for memory managment*/
+/* have zlib use oncalloc() and onfree() for memory management*/
 #define MY_ZCALLOC
 #endif
 


### PR DESCRIPTION
Found via `codespell -q 3 -S ./zlib,./freetype263 -L aline,ba,inout,lightyear,lightyears,lod,msdos,nd,ot,technic`