### PR TITLE
Fix buffer overflow in opennurbs_statics.cpp

### DIFF
--- a/opennurbs_statics.cpp
+++ b/opennurbs_statics.cpp
@@ -519,7 +519,7 @@ const ON_String ON_String::EmptyString;
 static const ON_String ON_Internal_ByteOrderMark()
 {
   // UTF-8 encoded byte order mark.
-  const unsigned char bom[3] = {0xEFU,0xBBU,0xBFU};
+  const unsigned char bom[4] = {0xEFU,0xBBU,0xBFU,0};
   return ON_String((const char*)bom);
 }
 const ON_String ON_String::ByteOrderMark(ON_Internal_ByteOrderMark());


### PR DESCRIPTION
XCode's address sanitizer detects a buffer overflow in:

int ON_String::Length(
  const char* s,
  size_t string_capacity
)

File: opennurbs_string.cpp. 
Line:
while (slen < string_capacity && 0 != *s++)
    slen++;

Which happens because the 'bom' is not null terminated.

This change makes 'bom' null terminated and fixes the buffer overflow.