### PR TITLE
fix: ON_Material::MaxShine is not a function

### DIFF
--- a/opennurbs_gl.cpp
+++ b/opennurbs_gl.cpp
@@ -600,7 +600,7 @@ void ON_GL( const ON_Material* pMat )
     ON_GL( pMat->Diffuse(), alpha, diffuse );
     ON_GL( pMat->Specular(), alpha, specular );
     ON_GL( pMat->Emission(), alpha, emission );
-    GLint shine = (GLint)(128.0*(pMat->Shine() / ON_Material::MaxShine()));
+    GLint shine = (GLint)(128.0*(pMat->Shine() / ON_Material::MaxShine));
     if ( shine == 0 ) {
       specular[0]=specular[1]=specular[2]=(GLfloat)0.0;
     }


### PR DESCRIPTION
Cherry-picked from #28 

- It fixes a bug in `opennurbs_gl` where ` ON_Material::MaxShine` which is a constant was being called as a function.
```cpp
C:/opennurbs/opennurbs_gl.cpp:603:71: error: called object type 'double' is not a function or function pointer
    GLint shine = (GLint)(128.0*(pMat->Shine() / ON_Material::MaxShine()));
                                                 ~~~~~~~~~~~~~~~~~~~~~^
```