### PR TITLE
Fix issues with constructors on GCC and Clang

### DIFF
--- a/opennurbs_lock.h
+++ b/opennurbs_lock.h
@@ -112,8 +112,8 @@ private:
   //         needs to have dll-interface to be used by clients of class 'ON_Lock'
   // m_lock_value is private and all code that manages m_lock_value is explicitly implemented in the DLL.
 private:
-#if defined(ON_COMPILER_CLANG)
-    std::atomic<int> m_lock_value;
+#if defined(ON_CLANG_CONSTRUCTOR_BUG_INIT)
+  std::atomic<int> m_lock_value;
 #else
   std::atomic<int> m_lock_value = ON_Lock::UnlockedValue;
 #endif

--- a/opennurbs_statics.cpp
+++ b/opennurbs_statics.cpp
@@ -515,7 +515,7 @@ static ON_SHA1_Hash ON_SHA1_Hash_EmptyContentHash()
 const ON_SHA1_Hash ON_SHA1_Hash::EmptyContentHash = ON_SHA1_Hash_EmptyContentHash();
 const ON_SHA1_Hash ON_SHA1_Hash::ZeroDigest ON_CLANG_CONSTRUCTOR_BUG_INIT(ON_SHA1_Hash);
 
-const ONX_ModelTest ONX_ModelTest::Unset ON_CLANG_CONSTRUCTOR_BUG_INIT(ONX_ModelTest);
+const ONX_ModelTest ONX_ModelTest::Unset = ONX_ModelTest();
 
 // Works with Microsoft's CL, fails for Apple's CLang
 ////   const struct ON_UnicodeErrorParameters ON_UnicodeErrorParameters::MaskErrors   = { 0, 0xFFFFFFFF, ON_UnicodeCodePoint::ON_ReplacementCharacter };
@@ -744,7 +744,7 @@ const ON_AngleUnitName ON_AngleUnitName::None ON_CLANG_CONSTRUCTOR_BUG_INIT(ON_A
 const ON_LengthValue ON_LengthValue::Unset ON_CLANG_CONSTRUCTOR_BUG_INIT(ON_LengthValue);
 const ON_LengthValue ON_LengthValue::Zero = ON_LengthValue::Create(0.0, ON::LengthUnitSystem::None, 0, ON_LengthValue::StringFormat::CleanDecimal);
 
-const ON_AngleValue ON_AngleValue::Unset ON_CLANG_CONSTRUCTOR_BUG_INIT(ON_AngleValue);
+const ON_AngleValue ON_AngleValue::Unset = ON_AngleValue();
 const ON_AngleValue ON_AngleValue::Zero = ON_AngleValue::Create(0.0, ON::AngleUnitSystem::None, 0, ON_AngleValue::StringFormat::CleanDecimal );
 
 const ON_ScaleValue ON_ScaleValue::Unset ON_CLANG_CONSTRUCTOR_BUG_INIT(ON_ScaleValue);


### PR DESCRIPTION
Cherry-picked from #28 

- It fixes the bugs related to not-initializing constants where default constructors are defaulted
```cpp
/home/aminya/opennurbs/opennurbs_statics.cpp:747:21: error: uninitialized const ‘ON_AngleValue::Unset’ [-fpermissive]
  747 | const ON_AngleValue ON_AngleValue::Unset ON_CLANG_CONSTRUCTOR_BUG_INIT(ON_AngleValue);
      |                     ^~~~~~~~~~~~~
In file included from /home/aminya/opennurbs/opennurbs.h:81,
                 from /home/aminya/opennurbs/opennurbs_statics.cpp:1:
/home/aminya/opennurbs/opennurbs_string_value.h:274:16: note: ‘const class ON_AngleValue’ has no user-provided default constructor
  274 | class ON_CLASS ON_AngleValue
      |                ^~~~~~~~~~~~~
/home/aminya/opennurbs/opennurbs_string_value.h:277:3: note: constructor is not user-provided because it is explicitly defaulted in the class body
  277 |   ON_AngleValue() = default;
      |   ^~~~~~~~~~~~~

```