### PR TITLE
fix: use unsigned int so that 0xFFFFFFFF can be stored

### DIFF
--- a/opennurbs_defines.h
+++ b/opennurbs_defines.h
@@ -2133,7 +2133,7 @@ public:
   // the values.  The reason for the gaps between the enum
   // values is to leave room for future snaps with prededence
   // falling between existing snaps
-  enum osnap_mode
+  enum osnap_mode: unsigned int
   {
     os_none          =          0,
     os_near          =          2,
@@ -2409,7 +2409,7 @@ public:
   // Do not change these values; they are stored in 3dm archives
   // and provide a persistent way to indentify components of
   // complex objects.
-  enum TYPE
+  enum TYPE: unsigned int
   {
     invalid_type       =   0,
 

--- a/opennurbs_object_history.cpp
+++ b/opennurbs_object_history.cpp
@@ -31,7 +31,7 @@ public:
   // The VALUE_TYPE enum values must never be changed
   // because the values are used to determine the parameter
   // type during file reading.  Additions can be made.
-  enum VALUE_TYPE
+  enum VALUE_TYPE: unsigned int
   {
     no_value_type         =  0,
 


### PR DESCRIPTION
Cherry-picked from #28 

- It fixes a bug where 0xFFFFFFFF was being narrowed down to int, which resulted in an error in the Clang compiler. This was fixed by adding `unsigned int` to the enums:
```cpp
C:/opennurbs/opennurbs_defines.cpp:2032:8: error: case value evaluates to -1, which cannot be narrowed to type 'unsigned int' [-Wc++11-narrowing]
  case os_all_snaps:     osm = os_all_snaps; break;
```