### PR TITLE
fix: fix building on C++20 - fix removal of shared_ptr.unique

### DIFF
--- a/opennurbs_mesh.cpp
+++ b/opennurbs_mesh.cpp
@@ -14833,7 +14833,7 @@ bool ON_MeshCache::Transform(
       continue;
     // NOTE: use_count() == 1 is an approximation in multi-threaded environments
     // https:// en.cppreference.com/w/cpp/memory/shared_ptr/unique
-    if (false == item->m_mesh_sp.use_count() == 1)
+    if (item->m_mesh_sp.use_count() != 1)
     {
       // make a copy and transform the copy
       std::shared_ptr<ON_Mesh>(new ON_Mesh(*mesh)).swap(item->m_mesh_sp);

--- a/opennurbs_mesh.cpp
+++ b/opennurbs_mesh.cpp
@@ -14831,7 +14831,9 @@ bool ON_MeshCache::Transform(
     ON_Mesh* mesh = item->m_mesh_sp.get();
     if (nullptr == mesh || mesh->IsEmpty())
       continue;
-    if (false == item->m_mesh_sp.unique())
+    // NOTE: use_count() == 1 is an approximation in multi-threaded environments
+    // https:// en.cppreference.com/w/cpp/memory/shared_ptr/unique
+    if (false == item->m_mesh_sp.use_count() == 1)
     {
       // make a copy and transform the copy
       std::shared_ptr<ON_Mesh>(new ON_Mesh(*mesh)).swap(item->m_mesh_sp);


### PR DESCRIPTION
This replaces the removed shared_ptr.unique with .use_count() == 1
See this for the explanation
https:// en.cppreference.com/w/cpp/memory/shared_ptr/unique

Cherry-picked from #28 

- It fixes building on C++ 20 by replacing the removed method `shraed_ptr.unique` with `shared_ptr.use_count == 1`
	https://en.cppreference.com/w/cpp/memory/shared_ptr/unique
```cpp
C:/opennurbs/opennurbs_mesh.cpp:14834:34: error: no member named 'unique' in 'std::shared_ptr<ON_Mesh>'
    if (false == item->m_mesh_sp.unique())
                 ~~~~~~~~~~~~~~~ ^
```
