### PR TITLE
fix: fix implicit conversion to ON_wString is not cross-architecture

### DIFF
--- a/opennurbs_file_utilities.cpp
+++ b/opennurbs_file_utilities.cpp
@@ -3302,13 +3302,13 @@ void ON_ContentHash::Dump(
 
     const ON_wString content_time
       = ( m_content_time <= 0 )
-      ? L"unknown"
+      ? static_cast<ON_wString>(L"unknown")
       : SecondsSinceJanOne1970UTCToString(m_content_time);
     text_log.Print(L"Content last modified time = %ls\n",static_cast<const wchar_t*>(content_time));
 
     const ON_wString hash_time
       = ( m_hash_time <= 0 )
-      ? L"unknown"
+      ? static_cast<ON_wString>(L"unknown")
       : SecondsSinceJanOne1970UTCToString(m_hash_time);
     text_log.Print(L"Content hash calculated time = %ls\n",static_cast<const wchar_t*>(content_time));
 

--- a/opennurbs_version_number.cpp
+++ b/opennurbs_version_number.cpp
@@ -375,7 +375,7 @@ const ON_String ON_VersionNumberToString(
     str_version =
       (0 != version_number)
       ? ON_String::FormatToString("0x%08X", version_number)
-      : "0";
+      : static_cast<ON_String>("0");
   }
 
   return str_version;


### PR DESCRIPTION
Cherry-picked from #28 

- fixing some string conversions such as on Windows ARM64
```cpp
C:\opennurbs\opennurbs_version_number.cpp(378,12): error C2445: result type of conditional expression is ambiguous: types 'const ON_String' and 'const char [2]' can be converted to multiple common types
```