### PR TITLE
fix: add arm64 preprocessor directives

### DIFF
--- a/opennurbs_file_utilities.cpp
+++ b/opennurbs_file_utilities.cpp
@@ -37,7 +37,7 @@
 #pragma ON_PRAGMA_WARNING_BEFORE_DIRTY_INCLUDE
 #include <Shlobj.h>
 #pragma ON_PRAGMA_WARNING_AFTER_DIRTY_INCLUDE
-#if defined(_M_X64) && defined(WIN32) && defined(WIN64)
+#if (defined(_M_X64) || defined(_M_ARM64)) && defined(WIN32) && defined(WIN64)
 // Shlwapi.h, Shlobj.h and perhaps others, unconditionally define WIN32
 #undef WIN32
 #endif

--- a/opennurbs_precompiledheader.cpp
+++ b/opennurbs_precompiledheader.cpp
@@ -32,9 +32,9 @@
 #error Incorrect _M_... setting for x64 build
 #endif
 
-#if !defined(_M_X64)
+#if !defined(_M_X64) && !defined(_M_ARM64)
 // This should be automatically defined by the compiler
-#error _M_X64 should be defined for x64 builds
+#error _M_X64 or _M_ARM64 should be defined for x64 or ARM64 builds
 #endif
 
 // All opennurbs code uses the "offical" _M_X64. Unfortunately, 
@@ -43,9 +43,9 @@
 // _M_X64 and _M_AMD64 for the WIN64 platform.  If it doesn't,
 // then we have a serious problem because some system header
 // files will not be correctly preprocessed.
-#if !defined(_M_AMD64)
+#if !defined(_M_AMD64) && !defined(_M_ARM64)
 // This should be automatically defined by the compiler
-#error _M_AMD64 should be defined for x64 builds
+#error _M_AMD64 or _M_ARM64 should be defined for x64 or ARM64 builds
 #endif
 
 #endif
@@ -57,7 +57,7 @@
 #error Microsoft defines _WIN32 for all Windows builds
 #endif
 
-#if defined(_M_IA64) || defined(_M_X64) || defined(_M_AMD64)
+#if defined(_M_IA64) || defined(_M_X64) || defined(_M_AMD64) || defined(_M_ARM64)
 #error Incorrect _M_... setting for 32 bit Windows build.
 #endif
 
@@ -108,9 +108,9 @@
 #error Incorrect _M_... setting for x64 build
 #endif
 
-#if !defined(_M_X64)
+#if !defined(_M_X64) && !defined(_M_ARM64)
 // This should be automatically defined by the compiler
-#error _M_X64 should be defined for x64 builds
+#error _M_X64 or _M_ARM64 should be defined for x64 or ARM64 builds
 #endif
 
 // All opennurbs code uses the "offical" _M_X64. Unfortunately, 
@@ -119,9 +119,9 @@
 // _M_X64 and _M_AMD64 for the WIN64 platform.  If it doesn't,
 // then we have a serious problem because some system header
 // files will not be correctly preprocessed.
-#if !defined(_M_AMD64)
+#if !defined(_M_AMD64) && !defined(_M_ARM64)
 // This should be automatically defined by the compiler
-#error _M_AMD64 should be defined for x64 builds
+#error _M_AMD64 or _M_ARM64 should be defined for x64 or ARM6 builds
 #endif
 
 #endif
@@ -133,7 +133,7 @@
 #error Microsoft defines _WIN32 for all Windows builds
 #endif
 
-#if defined(_M_IA64) || defined(_M_X64) || defined(_M_AMD64)
+#if defined(_M_IA64) || defined(_M_X64) || defined(_M_AMD64) || defined(_M_ARM64)
 #error Incorrect _M_... setting for 32 bit Windows build.
 #endif
 

--- a/opennurbs_system.h
+++ b/opennurbs_system.h
@@ -383,7 +383,7 @@ typedef ON__UINT32 wchar_t;
 */
 
 
-#if defined(_M_X64) && defined(WIN32) && defined(WIN64)
+#if (defined(_M_X64) || defined(_M_ARM64)) && defined(WIN32) && defined(WIN64)
 // 23 August 2007 Dale Lear
 
 #if defined(_INC_WINDOWS)
@@ -406,7 +406,7 @@ typedef ON__UINT32 wchar_t;
 #pragma ON_PRAGMA_WARNING_AFTER_DIRTY_INCLUDE
 #endif
 
-#if defined(_M_X64) && defined(WIN32) && defined(WIN64)
+#if (defined(_M_X64) || defined(_M_ARM64)) && defined(WIN32) && defined(WIN64)
 // 23 August 2007 Dale Lear
 //   windows.h unconditionally defines WIN32  This is a bug
 //   and the hope is this simple undef will let us continue.

--- a/opennurbs_system_runtime.h
+++ b/opennurbs_system_runtime.h
@@ -137,7 +137,7 @@
 #define ON_RUNTIME_WIN_WINOS
 #endif
 
-#if defined(_M_X64) || defined(_WIN64)
+#if defined(_M_X64) || defined(_M_ARM64) || defined(_WIN64)
 #define ON_64BIT_RUNTIME
 #elif defined(_M_X86) || defined(_WIN32)
 #define ON_32BIT_RUNTIME
@@ -146,7 +146,7 @@
 #endif
 
 #if !defined(ON_LITTLE_ENDIAN)
-#if (defined(_M_X64) || defined(_M_IX86) || defined (__i386__) || defined( __x86_64__ ))
+#if (defined(_M_X64) || defined(_M_ARM64) || defined(_M_IX86) || defined(__i386__) || defined(__x86_64__))
 #define ON_LITTLE_ENDIAN
 #endif
 #endif


### PR DESCRIPTION
Cherry-picked from #28 

This adds ARM64 directives for Windows