### PR TITLE
More consistent behavior between ON_Arc::SetAngleRadians() and ON_Arc…

### DIFF
--- a/opennurbs_arc.cpp
+++ b/opennurbs_arc.cpp
@@ -330,22 +330,24 @@ ON_Interval ON_Arc::DomainDegrees() const
 
 bool ON_Arc::SetAngleRadians( double a )
 {
+  ON_Interval angles;
   if ( a < 0.0 ) 
   {
     double a0 = m_angle.m_t[0];
-    m_angle.Set(a0+a,a0);
+    angles.Set(a0+a,a0);
     Reverse();
   }
   else
   {
-    m_angle.m_t[1] = m_angle.m_t[0] + a;
+    double a0 = m_angle.m_t[0];
+    angles.Set(a0, a0+a);
   }
-  return ( fabs(m_angle.Length()) <= 2.0*ON_PI ) ? true : false;
+  return SetAngleIntervalRadians(angles);
 }
 
 bool ON_Arc::SetAngleIntervalRadians( ON_Interval angle_in_radians )
 {
-  bool rc = angle_in_radians.IsIncreasing() 
+  bool rc = (angle_in_radians.IsIncreasing() || angle_in_radians.Length() < ON_EPSILON)
             && angle_in_radians.Length() < (1.0+ON_SQRT_EPSILON)*2.0*ON_PI;
   if (rc)
   {

--- a/opennurbs_arc.h
+++ b/opennurbs_arc.h
@@ -382,11 +382,14 @@ public:
   //   The arc's domain in degrees.
   ON_Interval DomainDegrees() const;
 
-  // Description:
-  //   Set arc's subtended angle in radians.
-  // Parameters:
-  //   angle_in_radians - [in] 0 <= angle_in_radians <= 2.0*ON_PI
-  //
+  /*
+  Description:
+    Set arc's subtended angle in radians.
+  Parameters:
+    angle_in_radians - [in] 0 <= angle_in_radians <= 2.0*ON_PI
+  Returns:
+    true if successful.
+  */
   bool SetAngleRadians(
     double angle_in_radians
     );


### PR DESCRIPTION
…::SetAngleIntervalRadians().

Now ON_Arc::SetAngleRadians() disallow to set angle interval with length more than 2*PI (returns false in this case) and ON_Arc::SetAngleIntervalRadians() allows to set empty interval