### PR TITLE
adding tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,7 @@ if (ANDROID OR LINUX)
 endif()
 
 add_subdirectory(zlib)
+add_subdirectory(tests)
 
 ## opennurbs static library
 add_library( opennurbsStatic STATIC

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Please see ["Getting started"](https://developer.rhino3d.com/guides/opennurbs/ge
 
 There's also a collection of [example 3dm files](example_files/) available for testing.
 
+## Building
+- `mkdir build && cd build`
+- `cmake ..`
+- `cmake --build .`
+
+This will also build the tests, which you can run by running them from the build/tests directory:
+
+- `cd tests`
+- `ctest`
+
+
 ## Questions?
 
 For technical support, please head over to [Discourse](https://discourse.mcneel.com/category/opennurbs).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.16)
+project(ON_Test)
+
+# GoogleTest requires at least C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+#set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+#set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/b10fad38c4026a29ea6561ab15fc4818170d1c10.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+add_executable(
+  hello_test
+  hello_test.cpp
+)
+
+target_link_libraries(
+  hello_test
+  GTest::gtest_main
+  OpenNURBS
+)
+
+include(GoogleTest)
+gtest_discover_tests(hello_test)

--- a/tests/hello_test.cpp
+++ b/tests/hello_test.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include "../opennurbs_public.h"
+
+# define M_PI           3.14159265358979323846  /* pi */
+
+TEST(HelloTest, BasicAssertions) {
+
+  ON_3dPoint center(0,0,0);
+
+  ON_Circle circle(center, 10.00);
+
+  double circumference = 2 * M_PI * circle.radius;
+
+  EXPECT_EQ(circumference, circle.Circumference());
+  
+}


### PR DESCRIPTION
This PR adds a `tests` subdirectory to the repository which has a CMakeLists.txt file and a sample test based on Google Test. Building ON also builds the tests. These can then be run from the resulting build/tests by running `ctest`