### PR TITLE
Fix crash when used in Blender.

### DIFF
--- a/zlib/infback.c
+++ b/zlib/infback.c
@@ -7,7 +7,7 @@
    This code is largely copied from inflate.c.  Normally either infback.o or
    inflate.o would be linked into an application--not both.  The interface
    with inffast.c is retained so that optimized assembler-coded versions of
-   inflate_fast() can be used with either inflate.c or infback.c.
+   zinflate_fast() can be used with either inflate.c or infback.c.
  */
 
 #include "zutil.h"
@@ -115,7 +115,7 @@ struct inflate_state FAR *state;
 
 /* Macros for inflateBack(): */
 
-/* Load returned state from inflate_fast() */
+/* Load returned state from zinflate_fast() */
 #define LOAD() \
     do { \
         put = strm->next_out; \
@@ -126,7 +126,7 @@ struct inflate_state FAR *state;
         bits = state->bits; \
     } while (0)
 
-/* Set state from registers for inflate_fast() */
+/* Set state from registers for zinflate_fast() */
 #define RESTORE() \
     do { \
         strm->next_out = put; \
@@ -462,12 +462,12 @@ void FAR *out_desc;
             state->mode = LEN;
 
         case LEN:
-            /* use inflate_fast() if we have enough input and output */
+            /* use zinflate_fast() if we have enough input and output */
             if (have >= 6 && left >= 258) {
                 RESTORE();
                 if (state->whave < state->wsize)
                     state->whave = state->wsize - left;
-                inflate_fast(strm, state->wsize);
+                zinflate_fast(strm, state->wsize);
                 LOAD();
                 break;
             }

--- a/zlib/inffast.c
+++ b/zlib/inffast.c
@@ -60,11 +60,11 @@
       checking for available input while decoding.
 
     - The maximum bytes that a single length/distance pair can output is 258
-      bytes, which is the maximum length that can be coded.  inflate_fast()
+      bytes, which is the maximum length that can be coded.  zinflate_fast()
       requires strm->avail_out >= 258 for each loop to avoid checking for
       output space.
  */
-void inflate_fast(strm, start)
+void zinflate_fast(strm, start)
 z_streamp strm;
 unsigned start;         /* inflate()'s starting value for strm->avail_out */
 {
@@ -302,7 +302,7 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
 }
 
 /*
-   inflate_fast() speedups that turned out slower (on a PowerPC G3 750CXe):
+   zinflate_fast() speedups that turned out slower (on a PowerPC G3 750CXe):
    - Using bit fields for code structure
    - Different op definition to avoid & for extra bits (do & for table bits)
    - Three separate decoding do-loops for direct, window, and write == 0

--- a/zlib/inffast.h
+++ b/zlib/inffast.h
@@ -8,4 +8,4 @@
    subject to change. Applications should only use zlib.h.
  */
 
-void inflate_fast OF((z_streamp strm, unsigned start));
+void zinflate_fast OF((z_streamp strm, unsigned start));

--- a/zlib/inflate.c
+++ b/zlib/inflate.c
@@ -31,24 +31,24 @@
  * - Add comments on op field in inftrees.h
  * - Fix bug in reuse of allocated window after inflateReset()
  * - Remove bit fields--back to byte structure for speed
- * - Remove distance extra == 0 check in inflate_fast()--only helps for lengths
- * - Change post-increments to pre-increments in inflate_fast(), PPC biased?
+ * - Remove distance extra == 0 check in zinflate_fast()--only helps for lengths
+ * - Change post-increments to pre-increments in zinflate_fast(), PPC biased?
  * - Add compile time option, POSTINC, to use post-increments instead (Intel?)
- * - Make MATCH copy in inflate() much faster for when inflate_fast() not used
+ * - Make MATCH copy in inflate() much faster for when zinflate_fast() not used
  * - Use local copies of stream next and avail values, as well as local bit
- *   buffer and bit count in inflate()--for speed when inflate_fast() not used
+ *   buffer and bit count in inflate()--for speed when zinflate_fast() not used
  *
  * 1.2.beta4    1 Jan 2003
  * - Split ptr - 257 statements in inflate_table() to avoid compiler warnings
  * - Move a comment on output buffer sizes from inffast.c to inflate.c
- * - Add comments in inffast.c to introduce the inflate_fast() routine
- * - Rearrange window copies in inflate_fast() for speed and simplification
- * - Unroll last copy for window match in inflate_fast()
- * - Use local copies of window variables in inflate_fast() for speed
- * - Pull out common write == 0 case for speed in inflate_fast()
- * - Make op and len in inflate_fast() unsigned for consistency
- * - Add FAR to lcode and dcode declarations in inflate_fast()
- * - Simplified bad distance check in inflate_fast()
+ * - Add comments in inffast.c to introduce the zinflate_fast() routine
+ * - Rearrange window copies in zinflate_fast() for speed and simplification
+ * - Unroll last copy for window match in zinflate_fast()
+ * - Use local copies of window variables in zinflate_fast() for speed
+ * - Pull out common write == 0 case for speed in zinflate_fast()
+ * - Make op and len in zinflate_fast() unsigned for consistency
+ * - Add FAR to lcode and dcode declarations in zinflate_fast()
+ * - Simplified bad distance check in zinflate_fast()
  * - Added inflateBackInit(), inflateBack(), and inflateBackEnd() in new
  *   source file infback.c to provide a call-back interface to inflate for
  *   programs like gzip and unzip -- uses window as output buffer to avoid
@@ -950,7 +950,7 @@ int flush;
         case LEN:
             if (have >= 6 && left >= 258) {
                 RESTORE();
-                inflate_fast(strm, out);
+                zinflate_fast(strm, out);
                 LOAD();
                 break;
             }


### PR DESCRIPTION
When OpenNURBS is used through rhino3dm in Blender there is a crash in Blender in its openvdb library due to the same named symbol inflate_fast.

Rename the one we have in our zlib library to zinflate_fast to prevent the crash from happening.